### PR TITLE
Calibration Rejection FW

### DIFF
--- a/src/drivers/stm32/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/stm32/tone_alarm/tone_alarm.cpp
@@ -678,12 +678,9 @@ tune_error:
 	// stop (and potentially restart) the tune
 tune_end:
 	stop_note();
-	if (_repeat) {
-		start_tune(_tune);
-	} else {
-		_tune = nullptr;
-		_default_tune_number = 0;
-	}
+
+	// Restart the error tones & play forever
+	start_tune(_tune);
 	return;
 }
 
@@ -806,13 +803,8 @@ ToneAlarm::write(file *filp, const char *buffer, size_t len)
 	if (buffer[0] == '\0')
 		return OK;
 
-	// allocate a copy of the new tune
-	_user_tune = strndup(buffer, len);
-	if (_user_tune == nullptr)
-		return -ENOMEM;
-
-	// and play it
-	start_tune(_user_tune);
+	// Play only a hardcoded error buzzer -- never the user requested tone
+	start_tune("ML<<CP4CP4CP4CP4CP4");
 
 	return len;
 }

--- a/src/modules/px4iofirmware/px4io.c
+++ b/src/modules/px4iofirmware/px4io.c
@@ -132,60 +132,22 @@ heartbeat_blink(void)
 static void
 ring_blink(void)
 {
-#ifdef GPIO_LED4
+    static unsigned counter = 0;
 
-	if (/* IO armed */ (r_status_flags & PX4IO_P_STATUS_FLAGS_SAFETY_OFF)
-	/* and FMU is armed */ && (r_setup_arming & PX4IO_P_SETUP_ARMING_FMU_ARMED)) {
-		LED_RING(1);
-		return;
-	}
-
-	// XXX this led code does have
-	// intentionally a few magic numbers.
-	const unsigned max_brightness = 118;
-
-	static unsigned counter = 0;
-	static unsigned brightness = max_brightness;
-	static unsigned brightness_counter = 0;
-	static unsigned on_counter = 0;
-
-	if (brightness_counter < max_brightness) {
-
-		bool on = ((on_counter * 100) / brightness_counter+1) <= ((brightness * 100) / max_brightness+1);
-
-		// XXX once led is PWM driven,
-		// remove the ! in the line below
-		// to return to the proper breathe
-		// animation / pattern (currently inverted)
-		LED_RING(!on);
-		brightness_counter++;
-
-		if (on) {
-			on_counter++;
-		}
-
-	} else {
-
-		if (counter >= 62) {
-			counter = 0;
-		}
-
-		int n;
-
-		if (counter < 32) {
-			n = counter;
-
-		} else {
-			n = 62 - counter;
-		}
-
-		brightness = (n * n) / 8;
-		brightness_counter = 0;
-		on_counter = 0;
-		counter++;
-	}
-
-#endif
+    //  Hardcoded fast-flash of all LEDs in synchrony
+    counter++;
+    if(counter >= 200) {
+	LED_RING(0);
+	LED_BLUE(0);
+	LED_AMBER(0);
+	LED_SAFETY(0);
+	if(counter >= 600)  counter = 0;
+    } else {
+	LED_RING(1);
+	LED_BLUE(1);
+	LED_AMBER(1);
+	LED_SAFETY(1);
+    }
 }
 
 static uint64_t reboot_time;


### PR DESCRIPTION
**\* DO NOT MERGE INTO MASTER ***
During final assembly and test if a PixHawk does not calibrate a
firmware with these changes should be installed instead of installing
an ordinary working firmware.

**\*  DO NOT MERGE THESE CHANGES INTO A MASTER BRANCH!!!! ****

This firmware indicates the PH is not safe to fly through two
indicators:
1. Rapid-blink the PixHawk's LED ring and other state LEDs in synchrony.
2. Play an error tone alarm continuously, never playing the user
requested tones
