### PR TITLE
oreoled v1.2 support

### DIFF
--- a/src/drivers/drv_oreoled.h
+++ b/src/drivers/drv_oreoled.h
@@ -85,6 +85,9 @@
 /** boot application */
 #define OREOLED_BL_BOOT_APP		_OREOLEDIOC(11)
 
+/** force an i2c gencall */
+#define OREOLED_FORCE_SYNC		_OREOLEDIOC(12)
+
 /* Oreo LED driver supports up to 4 leds */
 #define OREOLED_NUM_LEDS		4
 

--- a/src/drivers/oreoled/oreoled.cpp
+++ b/src/drivers/oreoled/oreoled.cpp
@@ -1467,6 +1467,10 @@ OREOLED::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 		return ret;
 
+	case OREOLED_FORCE_SYNC:
+		send_general_call();
+		break;
+
 	default:
 		/* see if the parent class can make any use of it */
 		ret = CDev::ioctl(filp, cmd, arg);


### PR DESCRIPTION
#### Highlights
1. Update LEDs based on the checksum of their firmware, not a version number
2. Re-acquire healthy LEDs which may have powered up into their bootloader with the wrong I2C address
3. Remove hard-coded version number and get version from firmware binary instead
4. Add ioctl support for forcing a sync/gencall, used by AP_Notify before rebooting

This depends on the pull request in ardupilot-solo by the same name.
