### PR TITLE
batt_smbus: read button status from the smart battery

### DIFF
--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -77,23 +77,25 @@
 #include <drivers/drv_batt_smbus.h>
 #include <drivers/device/ringbuffer.h>
 
-#define BATT_SMBUS_ADDR_MIN			0x08	///< lowest possible address
-#define BATT_SMBUS_ADDR_MAX			0x7F	///< highest possible address
+#define BATT_SMBUS_ADDR_MIN				0x08	///< lowest possible address
+#define BATT_SMBUS_ADDR_MAX				0x7F	///< highest possible address
 
-#define BATT_SMBUS_I2C_BUS			PX4_I2C_BUS_EXPANSION
-#define BATT_SMBUS_ADDR				0x0B	///< I2C address
-#define BATT_SMBUS_TEMP				0x08	///< temperature register
-#define BATT_SMBUS_VOLTAGE			0x09	///< voltage register
+#define BATT_SMBUS_I2C_BUS				PX4_I2C_BUS_EXPANSION
+#define BATT_SMBUS_ADDR					0x0B	///< I2C address
+#define BATT_SMBUS_TEMP					0x08	///< temperature register
+#define BATT_SMBUS_VOLTAGE				0x09	///< voltage register
 #define BATT_SMBUS_REMAINING_CAPACITY	0x0f	///< predicted remaining battery capacity as a percentage
 #define BATT_SMBUS_FULL_CHARGE_CAPACITY 0x10    ///< capacity when fully charged
 #define BATT_SMBUS_DESIGN_CAPACITY		0x18	///< design capacity register
 #define BATT_SMBUS_DESIGN_VOLTAGE		0x19	///< design voltage register
 #define BATT_SMBUS_SERIALNUM			0x1c	///< serial number register
 #define BATT_SMBUS_MANUFACTURE_NAME		0x20	///< manufacturer name
+#define BATT_SMBUS_MANUFACTURE_DATA		0x23	///< manufacturer data
 #define BATT_SMBUS_MANUFACTURE_INFO		0x25	///< cell voltage register
-#define BATT_SMBUS_CURRENT			0x2a	///< current register
-#define BATT_SMBUS_MEASUREMENT_INTERVAL_MS	(1000000 / 10)	///< time in microseconds, measure at 10hz
-#define BATT_SMBUS_TIMEOUT_MS		10000000	///< timeout looking for battery 10seconds after startup
+#define BATT_SMBUS_CURRENT				0x2a	///< current register
+#define BATT_SMBUS_MEASUREMENT_INTERVAL_US	(1000000 / 10)	///< time in microseconds, measure at 10hz
+#define BATT_SMBUS_TIMEOUT_US			10000000	///< timeout looking for battery 10seconds after startup
+#define BATT_SMBUS_BUTTON_DEBOUNCE_MS	300		///< button holds longer than this time will cause a power off event
 
 #define BATT_SMBUS_PEC_POLYNOMIAL		0x07	///< Polynomial for calculating PEC
 
@@ -187,6 +189,7 @@ private:
 	orb_id_t		_batt_orb_id;	///< uORB battery topic ID
 	uint64_t		_start_time;	///< system time we first attempt to communicate with battery
 	uint16_t		_batt_capacity;	///< battery's design capacity in mAh (0 means unknown)
+	uint8_t			_button_press_counts; ///< count of button presses detected
 };
 
 namespace
@@ -206,7 +209,8 @@ BATT_SMBUS::BATT_SMBUS(int bus, uint16_t batt_smbus_addr) :
 	_batt_topic(-1),
 	_batt_orb_id(nullptr),
 	_start_time(0),
-	_batt_capacity(0)
+	_batt_capacity(0),
+	_button_press_counts(0)
 {
 	// work_cancel in the dtor will explode if we don't do this...
 	memset(&_work, 0, sizeof(_work));
@@ -297,8 +301,8 @@ BATT_SMBUS::test()
 
 		if (updated) {
 			if (orb_copy(ORB_ID(battery_status), sub, &status) == OK) {
-				warnx("V=%4.2f C=%4.2f DismAh=%4.2f Cap:%d", (float)status.voltage_v, (float)status.current_a,
-				      (float)status.discharged_mah, (int)_batt_capacity);
+				warnx("V=%4.2f C=%4.2f DismAh=%4.2f Cap:%d Shutdown:%d", (float)status.voltage_v, (float)status.current_a,
+				      (float)status.discharged_mah, (int)_batt_capacity, (int)status.is_powering_off);
 			}
 		}
 
@@ -381,7 +385,7 @@ BATT_SMBUS::cycle()
 	uint64_t now = hrt_absolute_time();
 
 	// exit without rescheduling if we have failed to find a battery after 10 seconds
-	if (!_enabled && (now - _start_time > BATT_SMBUS_TIMEOUT_MS)) {
+	if (!_enabled && (now - _start_time > BATT_SMBUS_TIMEOUT_US)) {
 		warnx("did not find smart battery");
 		return;
 	}
@@ -403,7 +407,7 @@ BATT_SMBUS::cycle()
 		new_report.voltage_v = ((float)tmp) / 1000.0f;
 
 		// read current
-		uint8_t buff[4];
+		uint8_t buff[6];
 
 		if (read_block(BATT_SMBUS_CURRENT, buff, 4, false) == 4) {
 			new_report.current_a = -(float)((int32_t)((uint32_t)buff[3] << 24 | (uint32_t)buff[2] << 16 | (uint32_t)buff[1] << 8 |
@@ -423,6 +427,27 @@ BATT_SMBUS::cycle()
 				if (tmp < _batt_capacity) {
 					new_report.discharged_mah = _batt_capacity - tmp;
 				}
+			}
+		}
+
+		// read the button press indicator
+		if (read_block(BATT_SMBUS_MANUFACTURE_DATA, buff, 6, false) == 6) {
+			bool pressed = (buff[1] >> 3) & 0x01;
+
+			if(_button_press_counts >= ((BATT_SMBUS_BUTTON_DEBOUNCE_MS * 1000) / BATT_SMBUS_MEASUREMENT_INTERVAL_US)) {
+				// battery will power off
+				new_report.is_powering_off = true;
+				// warn only once
+				if(_button_press_counts++ == ((BATT_SMBUS_BUTTON_DEBOUNCE_MS * 1000) / BATT_SMBUS_MEASUREMENT_INTERVAL_US)) {
+					warnx("system is shutting down NOW...");
+				}
+			} else if(pressed) {
+				// battery will power off if the button is held
+				_button_press_counts++;
+			} else {
+				// button released early, reset counters
+				_button_press_counts = 0;
+				new_report.is_powering_off = false;
 			}
 		}
 
@@ -453,7 +478,7 @@ BATT_SMBUS::cycle()
 
 	// schedule a fresh cycle call when the measurement is done
 	work_queue(HPWORK, &_work, (worker_t)&BATT_SMBUS::cycle_trampoline, this,
-		   USEC2TICK(BATT_SMBUS_MEASUREMENT_INTERVAL_MS));
+		   USEC2TICK(BATT_SMBUS_MEASUREMENT_INTERVAL_US));
 }
 
 int

--- a/src/modules/uORB/topics/battery_status.h
+++ b/src/modules/uORB/topics/battery_status.h
@@ -57,6 +57,7 @@ struct battery_status_s {
 	float   	voltage_filtered_v;		/**< Battery voltage in volts, filtered, 0 if unknown  	 */
 	float		current_a;		/**< Battery current in amperes, -1 if unknown */
 	float		discharged_mah;		/**< Discharged amount in mAh, -1 if unknown	 */
+	bool		is_powering_off;	/**< Power off event imminent indication, false if unknown */
 };
 
 /**


### PR DESCRIPTION
Reads the "button pressed" register from the solo smart battery and counts "pressed" events to debounce single presses from long holds, which will shut off the battery within 2 seconds.

Also adds `bool is_powering_off` to the `battery_status_s` uORB `battery_status` topic.

The intention is to use the `is_powering_off` indicator to notify connected subsystems (gimbals, companion computers etc.) that power will be terminated imminently, so they can either shutdown gracefully or at least prepare to lose power (for filesystem sync etc).

The "button pressed" `bit` comes from the `Manufacturer Data` register block on the battery, so this may only work with the solo smart battery.

@rmackay9 Would you mind looking over this?