### PR TITLE
oreoled: cleanup and refactoring

### DIFF
--- a/makefiles/config_px4fmu-v2_default.mk
+++ b/makefiles/config_px4fmu-v2_default.mk
@@ -44,6 +44,7 @@ MODULES		+= modules/sensors
 MODULES		+= drivers/mkblctrl
 MODULES		+= drivers/px4flow
 MODULES		+= drivers/oreoled
+MODULES		+= drivers/oreoled/oreoled_bootloader
 
 #
 # System commands

--- a/src/drivers/drv_oreoled.h
+++ b/src/drivers/drv_oreoled.h
@@ -64,29 +64,8 @@
 /** send reset */
 #define OREOLED_SEND_RESET		_OREOLEDIOC(4)
 
-/** boot ping */
-#define OREOLED_BL_PING			_OREOLEDIOC(5)
-
-/** boot version */
-#define OREOLED_BL_VER			_OREOLEDIOC(6)
-
-/** boot write flash */
-#define OREOLED_BL_FLASH		_OREOLEDIOC(7)
-
-/** boot application version */
-#define OREOLED_BL_APP_VER		_OREOLEDIOC(8)
-
-/** boot application crc */
-#define OREOLED_BL_APP_CRC		_OREOLEDIOC(9)
-
-/** boot startup colour */
-#define OREOLED_BL_SET_COLOUR	_OREOLEDIOC(10)
-
-/** boot application */
-#define OREOLED_BL_BOOT_APP		_OREOLEDIOC(11)
-
 /** force an i2c gencall */
-#define OREOLED_FORCE_SYNC		_OREOLEDIOC(12)
+#define OREOLED_FORCE_SYNC		_OREOLEDIOC(5)
 
 /* Oreo LED driver supports up to 4 leds */
 #define OREOLED_NUM_LEDS		4
@@ -102,39 +81,6 @@
 
 /* maximum number of commands retries */
 #define OEROLED_COMMAND_RETRIES	2
-#define OEROLED_BOOT_COMMAND_RETRIES 10
-
-/* magic number used to verify the software reset is valid */
-#define OEROLED_RESET_NONCE				0x2A
-
-/* microseconds to hold-off between write and reads */
-#define OREOLED_WRITE_READ_HOLDOFF_US	500
-
-/* microseconds to hold-off between retries */
-#define OREOLED_RETRY_HOLDOFF_US		200
-
-#define OREOLED_BOOT_FLASH_WAITMS		10
-
-#define OREOLED_BOOT_SUPPORTED_VER		0x01
-
-#define OREOLED_BOOT_CMD_PING			0x40
-#define OREOLED_BOOT_CMD_BL_VER			0x41
-#define OREOLED_BOOT_CMD_APP_VER		0x42
-#define OREOLED_BOOT_CMD_APP_CRC		0x43
-#define OREOLED_BOOT_CMD_SET_COLOUR		0x44
-
-#define OREOLED_BOOT_CMD_WRITE_FLASH_A	0x50
-#define OREOLED_BOOT_CMD_WRITE_FLASH_B	0x51
-#define OREOLED_BOOT_CMD_FINALISE_FLASH	0x55
-
-#define OREOLED_BOOT_CMD_BOOT_APP		0x60
-
-#define OREOLED_BOOT_CMD_PING_NONCE		0x2A
-#define OREOLED_BOOT_CMD_BOOT_NONCE		0xA2
-
-#define OREOLED_FW_FILE_HEADER_LENGTH	2
-#define OREOLED_FW_FILE_SIZE_LIMIT		6144
-#define OREOLED_FW_FILE					"/etc/firmware/oreoled.bin"
 
 /* enum passed to OREOLED_SET_MODE ioctl()
  *	defined by hardware */

--- a/src/drivers/drv_oreoled.h
+++ b/src/drivers/drv_oreoled.h
@@ -70,6 +70,9 @@
 /* Oreo LED driver supports up to 4 leds */
 #define OREOLED_NUM_LEDS		4
 
+/* base i2c address (7-bit) */
+#define OREOLED_BASE_I2C_ADDR	0x68
+
 /* instance of 0xff means apply to all instances */
 #define OREOLED_ALL_INSTANCES	0xff
 

--- a/src/drivers/drv_oreoled.h
+++ b/src/drivers/drv_oreoled.h
@@ -101,7 +101,8 @@
 #define OREOLED_CMD_READ_LENGTH_MAX	10
 
 /* maximum number of commands retries */
-#define OEROLED_COMMAND_RETRIES	10
+#define OEROLED_COMMAND_RETRIES	2
+#define OEROLED_BOOT_COMMAND_RETRIES 10
 
 /* magic number used to verify the software reset is valid */
 #define OEROLED_RESET_NONCE				0x2A
@@ -112,7 +113,6 @@
 /* microseconds to hold-off between retries */
 #define OREOLED_RETRY_HOLDOFF_US		200
 
-#define OEROLED_BOOT_COMMAND_RETRIES	25
 #define OREOLED_BOOT_FLASH_WAITMS		10
 
 #define OREOLED_BOOT_SUPPORTED_VER		0x01

--- a/src/drivers/drv_oreoled_bootloader.h
+++ b/src/drivers/drv_oreoled_bootloader.h
@@ -1,0 +1,77 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2012-2013 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file drv_oreoled.h
+ * @author Angus Peart <angusp@gmail.com>
+ * OreoLED bootloader device API
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/ioctl.h>
+
+/* oreoled device path */
+#define OREOLEDBL0_DEVICE_PATH "/dev/oreoledbl0"
+
+/*
+ * ioctl() definitions
+ */
+
+#define _OREOLED_BL_IOC_BASE	(0x2f00)
+#define _OREOLED_BL_IOC(_n)		(_IOC(_OREOLED_BL_IOC_BASE, _n))
+
+/** send reset */
+#define OREOLED_BL_RESET		_OREOLED_BL_IOC(1)
+
+/** boot ping */
+#define OREOLED_BL_PING			_OREOLED_BL_IOC(2)
+
+/** boot version */
+#define OREOLED_BL_VER			_OREOLED_BL_IOC(3)
+
+/** boot write flash */
+#define OREOLED_BL_FLASH		_OREOLED_BL_IOC(4)
+
+/** boot application version */
+#define OREOLED_BL_APP_VER		_OREOLED_BL_IOC(5)
+
+/** boot application crc */
+#define OREOLED_BL_APP_CHECKSUM	_OREOLED_BL_IOC(6)
+
+/** boot startup colour */
+#define OREOLED_BL_SET_COLOUR	_OREOLED_BL_IOC(7)
+
+/** boot application */
+#define OREOLED_BL_BOOT_APP		_OREOLED_BL_IOC(8)

--- a/src/drivers/oreoled/oreoled.cpp
+++ b/src/drivers/oreoled/oreoled.cpp
@@ -66,8 +66,6 @@
 #include <drivers/drv_oreoled.h>
 #include <drivers/device/ringbuffer.h>
 
-#define OREOLED_NUM_LEDS		4			///< maximum number of LEDs the oreo led driver can support
-#define OREOLED_BASE_I2C_ADDR	0x68		///< base i2c address (7-bit)
 #define OPEOLED_I2C_RETRYCOUNT  2           ///< i2c retry count
 #define OREOLED_TIMEOUT_USEC	1000000U	///< timeout looking for oreoleds 1 second after startup
 #define OREOLED_GENERALCALL_US	2000000U	///< general call sent every 2 seconds

--- a/src/drivers/oreoled/oreoled.cpp
+++ b/src/drivers/oreoled/oreoled.cpp
@@ -75,8 +75,8 @@
 #define OREOLED_GENERALCALL_US	4000000U	///< general call sent every 4 seconds
 #define OREOLED_GENERALCALL_CMD	0x00		///< general call command sent at regular intervals
 
-#define OREOLED_STARTUP_INTERVAL_US		(1000000U / 10U)	///< time in microseconds, measure at 10hz
-#define OREOLED_UPDATE_INTERVAL_US		(1000000U / 50U)	///< time in microseconds, measure at 10hz
+#define OREOLED_STARTUP_INTERVAL_US		(1000000U / 10U)	///< time in microseconds, run at 10hz
+#define OREOLED_UPDATE_INTERVAL_US		(1000000U / 50U)	///< time in microseconds, run at 50hz
 
 #define OREOLED_CMD_QUEUE_SIZE	10		///< up to 10 messages can be queued up to send to the LEDs
 
@@ -122,7 +122,12 @@ private:
 	 */
 	void			cycle();
 
+	void			run_initial_discovery(void);
+	void			run_updates(void);
+
+	void			bootloader_update_application(bool force_update);
 	int				bootloader_app_reset(int led_num);
+	int				bootloader_app_reset_all(void);
 	int				bootloader_app_ping(int led_num);
 	uint16_t		bootloader_inapp_checksum(int led_num);
 	int				bootloader_ping(int led_num);
@@ -131,9 +136,12 @@ private:
 	uint16_t		bootloader_app_checksum(int led_num);
 	int				bootloader_set_colour(int led_num, uint8_t red, uint8_t green);
 	int				bootloader_flash(int led_num);
+	int				bootloader_flash_all(bool force_update);
 	int				bootloader_boot(int led_num);
+	int				bootloader_boot_all(void);
 	uint16_t		bootloader_fw_checksum(void);
 	int				bootloader_coerce_healthy(void);
+	void			bootloader_cmd_add_checksum(oreoled_cmd_t* cmd);
 
 	/* internal variables */
 	work_s			_work;							///< work queue for scheduling reads
@@ -306,186 +314,21 @@ OREOLED::cycle()
 	uint64_t now = hrt_absolute_time();
 	bool startup_timeout = (now - _start_time > OREOLED_TIMEOUT_USEC);
 
-	/* prepare the response buffer */
-	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-
 	/* during startup period keep searching for unhealthy LEDs */
 	if (!startup_timeout && _num_healthy < OREOLED_NUM_LEDS) {
-		/* prepare command to turn off LED */
-		/* add two bytes of pre-amble to for higher signal to noise ratio */
-		uint8_t msg[] = {0xAA, 0x55, OREOLED_PATTERN_OFF, 0x00};
-
-		/* attempt to contact each unhealthy LED */
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (!_healthy[i]) {
-				perf_begin(_probe_perf);
-
-				/* set I2C address */
-				set_address(OREOLED_BASE_I2C_ADDR + i);
-
-				/* Calculate XOR CRC and append to the i2c write data */
-				msg[sizeof(msg) - 1] = OREOLED_BASE_I2C_ADDR + i;
-
-				for (uint8_t j = 0; j < sizeof(msg) - 1; j++) {
-					msg[sizeof(msg) - 1] ^= msg[j];
-				}
-
-				/* send I2C command */
-				if (transfer(msg, sizeof(msg), reply, 3) == OK) {
-					if (reply[1] == OREOLED_BASE_I2C_ADDR + i &&
-					    reply[2] == msg[sizeof(msg) - 1]) {
-						log("oreoled %u ok - in bootloader", (unsigned)i);
-						_healthy[i] = true;
-						_num_healthy++;
-
-						/* If slaves are in application record that so we can reset if we need to bootload */
-						/* This additional check is required for LED firmwares below v1.3 and can be
-						   deprecated once all LEDs in the wild have firmware >= v1.3 */
-						if(bootloader_ping(i) == OK) {
-							_in_boot[i] = true;
-							_num_inboot++;
-						}
-
-					/* Check for a reply with a checksum offset of 1,
-					   which indicates a response from firmwares >= 1.3 */
-					} else if (reply[1] == OREOLED_BASE_I2C_ADDR + i &&
-					    reply[2] == msg[sizeof(msg) - 1] + 1) {
-						log("oreoled %u ok - in application", (unsigned)i);
-						_healthy[i] = true;
-						_num_healthy++;
-
-					} else {
-						log("oreo reply errors: %u", (unsigned)_reply_errors);
-						perf_count(_reply_errors);
-					}
-
-				} else {
-					perf_count(_comms_errors);
-				}
-
-				perf_end(_probe_perf);
-			}
-		}
+		run_initial_discovery();
 
 		/* schedule another attempt in 0.1 sec */
 		work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this,
 			   USEC2TICK(OREOLED_STARTUP_INTERVAL_US));
 		return;
+	} else if (_alwaysupdate || _autoupdate || _num_inboot || _is_ready) {
+		run_updates();
 
-	} else if (_alwaysupdate) {
-		/* reset each healthy LED */
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i] && !_in_boot[i]) {
-				/* reset the LED if it's not in the bootloader */
-				/* (this happens during a pixhawk OTA update, since the LEDs stay powered) */
-				bootloader_app_reset(i);
-			}
-		}
-
-		/* attempt to update each healthy LED */
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i] && _in_boot[i]) {
-				/* flash the new firmware */
-				bootloader_flash(i);
-			}
-		}
-
-		/* boot each healthy LED */
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i] && _in_boot[i]) {
-				/* boot the application */
-				bootloader_boot(i);
-			}
-		}
-
-		/* coerce LEDs with startup issues to be healthy again */
-		bootloader_coerce_healthy();
-
-		/* mandatory updating has finished */
-		_alwaysupdate = false;
-
-		/* schedule a fresh cycle call when the measurement is done */
+		/* schedule another attempt in 20mS */
 		work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this,
 			   USEC2TICK(OREOLED_UPDATE_INTERVAL_US));
 		return;
-
-	} else if (_autoupdate) {
-		/* check booted oreoleds to see if the app can report it's checksum (release versions >= v1.2) */
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i] && !_in_boot[i]) {
-				/* put any out of date oreoleds into bootloader mode */
-				/* being in bootloader mode signals to be code below that the will likey need updating */
-				if (bootloader_inapp_checksum(i) != bootloader_fw_checksum()) {
-					bootloader_app_reset(i);
-				}
-			}
-		}
-
-		/* reset all healthy oreoleds if the number of outdated oreoled's is > 0 */
-		/* this is done for consistency, so if only one oreoled is updating, all LEDs show the same behaviour */
-		/* otherwise a single oreoled could appear broken or failed. */
-		if (_num_inboot > 0) {
-			for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-				if (_healthy[i] && !_in_boot[i]) {
-					/* reset the LED if it's not in the bootloader */
-					/* (this happens during a pixhawk OTA update, since the LEDs stay powered) */
-					bootloader_app_reset(i);
-				}
-			}
-
-			/* update each outdated and healthy LED in bootloader mode */
-			for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-				if (_healthy[i] && _in_boot[i]) {
-					/* only flash LEDs with an old version of the applictioon */
-					if (bootloader_app_checksum(i) != bootloader_fw_checksum()) {
-						/* flash the new firmware */
-						bootloader_flash(i);
-					}
-				}
-			}
-
-			/* boot each healthy LED */
-			for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-				if (_healthy[i] && _in_boot[i]) {
-					/* boot the application */
-					bootloader_boot(i);
-				}
-			}
-
-			/* coerce LEDs with startup issues to be healthy again */
-			bootloader_coerce_healthy();
-		}
-
-		/* auto updating has finished */
-		_autoupdate = false;
-
-		/* schedule a fresh cycle call when the measurement is done */
-		work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this,
-			   USEC2TICK(OREOLED_UPDATE_INTERVAL_US));
-		return;
-
-	} else if (_num_inboot > 0) {
-		/* boot any LEDs which are in still in bootloader mode */
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_in_boot[i]) {
-				bootloader_boot(i);
-			}
-		}
-
-		/* coerce LEDs with startup issues to be healthy again */
-		bootloader_coerce_healthy();
-
-		/* ensure we don't get stuck in a loop */
-		_num_inboot = 0;
-
-		/* schedule a fresh cycle call when the measurement is done */
-		work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this,
-			   USEC2TICK(OREOLED_UPDATE_INTERVAL_US));
-		return;
-
-	} else if (!_is_ready) {
-		/* indicate a ready state since startup has finished */
-		_is_ready = true;
 	}
 
 	/* get next command from queue */
@@ -503,25 +346,23 @@ OREOLED::cycle()
 
 			/* Calculate XOR CRC and append to the i2c write data */
 			uint8_t next_cmd_xor = OREOLED_BASE_I2C_ADDR + next_cmd.led_num;
-
 			for (uint8_t i = 0; i < next_cmd.num_bytes; i++) {
 				next_cmd_xor ^= next_cmd.buff[i];
 			}
-
 			next_cmd.buff[next_cmd.num_bytes++] = next_cmd_xor;
 
 			/* send I2C command with a retry limit */
+			uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
 			for (uint8_t retry = OEROLED_COMMAND_RETRIES; retry > 0; retry--) {
 				if (transfer(next_cmd.buff, next_cmd.num_bytes, reply, 3) == OK) {
-					if (reply[1] == (OREOLED_BASE_I2C_ADDR + next_cmd.led_num) && reply[2] == next_cmd_xor) {
-						/* slave returned a valid response */
-						break;
-
-					} else {
+					if (!(reply[1] == (OREOLED_BASE_I2C_ADDR + next_cmd.led_num) && reply[2] == next_cmd_xor)) {
+						_healthy[next_cmd.led_num] = false;
+						_num_healthy--;
 						perf_count(_reply_errors);
 					}
-
 				} else {
+					_healthy[next_cmd.led_num] = false;
+					_num_healthy--;
 					perf_count(_comms_errors);
 				}
 			}
@@ -542,6 +383,119 @@ OREOLED::cycle()
 		   USEC2TICK(OREOLED_UPDATE_INTERVAL_US));
 }
 
+void
+OREOLED::run_initial_discovery(void)
+{
+	/* prepare command to turn off LED */
+	/* add two bytes of pre-amble to for higher signal to noise ratio */
+	uint8_t msg[] = {0xAA, 0x55, OREOLED_PATTERN_OFF, 0x00};
+
+	/* attempt to contact each unhealthy LED */
+	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+		if (!_healthy[i]) {
+			perf_begin(_probe_perf);
+
+			/* set I2C address */
+			set_address(OREOLED_BASE_I2C_ADDR + i);
+
+			/* Calculate XOR CRC and append to the i2c write data */
+			msg[sizeof(msg) - 1] = OREOLED_BASE_I2C_ADDR + i;
+
+			for (uint8_t j = 0; j < sizeof(msg) - 1; j++) {
+				msg[sizeof(msg) - 1] ^= msg[j];
+			}
+
+			/* send I2C command */
+			uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+			if (transfer(msg, sizeof(msg), reply, 3) == OK) {
+				if (reply[1] == OREOLED_BASE_I2C_ADDR + i &&
+				    reply[2] == msg[sizeof(msg) - 1]) {
+					log("oreoled %u ok - in bootloader", (unsigned)i);
+					_healthy[i] = true;
+					_num_healthy++;
+
+					/* If slaves are in application record that so we can reset if we need to bootload */
+					/* This additional check is required for LED firmwares below v1.3 and can be
+					   deprecated once all LEDs in the wild have firmware >= v1.3 */
+					if(bootloader_ping(i) == OK) {
+						_in_boot[i] = true;
+						_num_inboot++;
+					}
+
+				/* Check for a reply with a checksum offset of 1,
+				   which indicates a response from firmwares >= 1.3 */
+				} else if (reply[1] == OREOLED_BASE_I2C_ADDR + i &&
+				    reply[2] == msg[sizeof(msg) - 1] + 1) {
+					log("oreoled %u ok - in application", (unsigned)i);
+					_healthy[i] = true;
+					_num_healthy++;
+
+				} else {
+					log("oreo reply errors: %u", (unsigned)_reply_errors);
+					perf_count(_reply_errors);
+				}
+
+			} else {
+				perf_count(_comms_errors);
+			}
+
+			perf_end(_probe_perf);
+		}
+	}
+}
+
+void
+OREOLED::run_updates(void)
+{
+	if (_alwaysupdate) {
+		bootloader_update_application(true);
+		_alwaysupdate = false;
+	} else if (_autoupdate) {
+		bootloader_update_application(false);
+		_autoupdate = false;
+	} else if (_num_inboot > 0) {
+		bootloader_boot_all();
+		bootloader_coerce_healthy();
+		_num_inboot = 0;
+	} else if (!_is_ready) {
+		/* indicate a ready state since startup has finished */
+		_is_ready = true;
+	}
+}
+
+void
+OREOLED::bootloader_update_application(bool force_update)
+{
+	/* check booted oreoleds to see if the app can report it's checksum (release versions >= v1.2) */
+	if(!force_update) {
+		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+			if (_healthy[i] && !_in_boot[i]) {
+				/* put any out of date oreoleds into bootloader mode */
+				/* being in bootloader mode signals to be code below that the will likey need updating */
+				if (bootloader_inapp_checksum(i) != bootloader_fw_checksum()) {
+					bootloader_app_reset(i);
+				}
+			}
+		}
+	}
+
+	/* reset all healthy oreoleds if the number of outdated oreoled's is > 0 */
+	/* this is done for consistency, so if only one oreoled is updating, all LEDs show the same behaviour */
+	/* otherwise a single oreoled could appear broken or failed. */
+	if (_num_inboot > 0 || force_update) {
+		bootloader_app_reset_all();
+
+		/* update each outdated and healthy LED in bootloader mode */
+		bootloader_flash_all(force_update);
+
+		/* boot each healthy LED */
+		bootloader_boot_all();
+
+		/* coerce LEDs with startup issues to be healthy again */
+		bootloader_coerce_healthy();
+	}
+}
+
 int
 OREOLED::bootloader_app_reset(int led_num)
 {
@@ -560,15 +514,12 @@ OREOLED::bootloader_app_reset(int led_num)
 	boot_cmd.buff[2] = OEROLED_RESET_NONCE;
 	boot_cmd.buff[3] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 	boot_cmd.num_bytes = 4;
-
-	for (uint8_t j = 0; j < boot_cmd.num_bytes - 1; j++) {
-		boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[j];
-	}
+	bootloader_cmd_add_checksum(&boot_cmd);
 
 	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
 
 	/* send I2C command with a retry limit */
-	for (uint8_t retry = OEROLED_COMMAND_RETRIES; retry > 0; retry--) {
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
 		if (transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 3) == OK) {
 			if (reply[1] == (OREOLED_BASE_I2C_ADDR + boot_cmd.led_num) &&
 			    reply[2] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
@@ -593,6 +544,24 @@ OREOLED::bootloader_app_reset(int led_num)
 }
 
 int
+OREOLED::bootloader_app_reset_all(void)
+{
+	int ret = OK;
+
+	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+		if (_healthy[i] && !_in_boot[i]) {
+			/* reset the LED if it's not in the bootloader */
+			/* (this happens during a pixhawk OTA update, since the LEDs stay powered) */
+			if (bootloader_app_reset(i) != OK) {
+				ret = -1;
+			}
+		}
+	}
+
+	return ret;
+}
+
+int
 OREOLED::bootloader_app_ping(int led_num)
 {
 	oreoled_cmd_t boot_cmd;
@@ -609,15 +578,12 @@ OREOLED::bootloader_app_ping(int led_num)
 	boot_cmd.buff[2] = OREOLED_PATTERN_OFF;
 	boot_cmd.buff[3] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 	boot_cmd.num_bytes = 4;
-
-	for (uint8_t j = 0; j < boot_cmd.num_bytes - 1; j++) {
-		boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[j];
-	}
+	bootloader_cmd_add_checksum(&boot_cmd);
 
 	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
 
 	/* send I2C command with a retry limit */
-	for (uint8_t retry = OEROLED_COMMAND_RETRIES; retry > 0; retry--) {
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
 		if (transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 3) == OK) {
 			if (reply[1] == (OREOLED_BASE_I2C_ADDR + boot_cmd.led_num) &&
 			    reply[2] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
@@ -647,14 +613,11 @@ OREOLED::bootloader_inapp_checksum(int led_num)
 	boot_cmd.buff[1] = OREOLED_PARAM_APP_CHECKSUM;
 	boot_cmd.buff[2] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 	boot_cmd.num_bytes = 3;
-
-	for (uint8_t j = 0; j < boot_cmd.num_bytes - 1; j++) {
-		boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[j];
-	}
+	bootloader_cmd_add_checksum(&boot_cmd);
 
 	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
 
-	for (uint8_t retry = OEROLED_COMMAND_RETRIES; retry > 0; retry--) {
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
 		/* Send the I2C Write+Read */
 		memset(reply, 0, sizeof(reply));
 		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 6);
@@ -706,10 +669,7 @@ OREOLED::bootloader_ping(int led_num)
 	boot_cmd.buff[0] = OREOLED_BOOT_CMD_PING;
 	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 	boot_cmd.num_bytes = 2;
-
-	for (uint8_t j = 0; j < boot_cmd.num_bytes - 1; j++) {
-		boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[j];
-	}
+	bootloader_cmd_add_checksum(&boot_cmd);
 
 	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
 
@@ -763,10 +723,7 @@ OREOLED::bootloader_version(int led_num)
 	boot_cmd.buff[0] = OREOLED_BOOT_CMD_BL_VER;
 	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 	boot_cmd.num_bytes = 2;
-
-	for (uint8_t k = 0; k < boot_cmd.num_bytes - 1; k++) {
-		boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[k];
-	}
+	bootloader_cmd_add_checksum(&boot_cmd);
 
 	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
 
@@ -819,10 +776,7 @@ OREOLED::bootloader_app_version(int led_num)
 	boot_cmd.buff[0] = OREOLED_BOOT_CMD_APP_VER;
 	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 	boot_cmd.num_bytes = 2;
-
-	for (uint8_t j = 0; j < boot_cmd.num_bytes - 1; j++) {
-		boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[j];
-	}
+	bootloader_cmd_add_checksum(&boot_cmd);
 
 	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
 
@@ -878,10 +832,7 @@ OREOLED::bootloader_app_checksum(int led_num)
 	boot_cmd.buff[0] = OREOLED_BOOT_CMD_APP_CRC;
 	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 	boot_cmd.num_bytes = 2;
-
-	for (uint8_t j = 0; j < boot_cmd.num_bytes - 1; j++) {
-		boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[j];
-	}
+	bootloader_cmd_add_checksum(&boot_cmd);
 
 	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
 
@@ -939,10 +890,7 @@ OREOLED::bootloader_set_colour(int led_num, uint8_t red, uint8_t green)
 	boot_cmd.buff[2] = green;
 	boot_cmd.buff[3] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 	boot_cmd.num_bytes = 4;
-
-	for (uint8_t j = 0; j < boot_cmd.num_bytes - 1; j++) {
-		boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[j];
-	}
+	bootloader_cmd_add_checksum(&boot_cmd);
 
 	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
 
@@ -1049,10 +997,7 @@ OREOLED::bootloader_flash(int led_num)
 		memcpy(boot_cmd.buff + 2, buf + (page_idx * 64) + OREOLED_FW_FILE_HEADER_LENGTH, 32);
 		boot_cmd.buff[32 + 2] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 		boot_cmd.num_bytes = 32 + 3;
-
-		for (uint8_t k = 0; k < boot_cmd.num_bytes - 1; k++) {
-			boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[k];
-		}
+		bootloader_cmd_add_checksum(&boot_cmd);
 
 		for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
 			/* Send the I2C Write+Read */
@@ -1089,10 +1034,7 @@ OREOLED::bootloader_flash(int led_num)
 		memcpy(boot_cmd.buff + 1, buf + (page_idx * 64) + 32 + OREOLED_FW_FILE_HEADER_LENGTH, 32);
 		boot_cmd.buff[32 + 1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 		boot_cmd.num_bytes = 32 + 2;
-
-		for (uint8_t k = 0; k < boot_cmd.num_bytes - 1; k++) {
-			boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[k];
-		}
+		bootloader_cmd_add_checksum(&boot_cmd);
 
 		for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
 			/* Send the I2C Write+Read */
@@ -1145,10 +1087,7 @@ OREOLED::bootloader_flash(int led_num)
 	boot_cmd.buff[6] = (uint8_t)(app_checksum & 0xFF);
 	boot_cmd.buff[7] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 	boot_cmd.num_bytes = 8;
-
-	for (uint8_t k = 0; k < boot_cmd.num_bytes - 1; k++) {
-		boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[k];
-	}
+	bootloader_cmd_add_checksum(&boot_cmd);
 
 	/* Try to finalise for twice the amount of normal retries */
 	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES * 2; retry > 0; retry--) {
@@ -1206,10 +1145,7 @@ OREOLED::bootloader_boot(int led_num)
 	boot_cmd.buff[1] = OREOLED_BOOT_CMD_BOOT_NONCE;
 	boot_cmd.buff[2] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
 	boot_cmd.num_bytes = 3;
-
-	for (uint8_t k = 0; k < boot_cmd.num_bytes - 1; k++) {
-		boot_cmd.buff[boot_cmd.num_bytes - 1] ^= boot_cmd.buff[k];
-	}
+	bootloader_cmd_add_checksum(&boot_cmd);
 
 	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
 		/* Send the I2C Write */
@@ -1255,6 +1191,22 @@ OREOLED::bootloader_boot(int led_num)
 	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
 
 	_is_bootloading = false;
+	return ret;
+}
+
+int
+OREOLED::bootloader_boot_all(void) {
+	int ret = OK;
+
+	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+		if (_healthy[i] && _in_boot[i]) {
+			/* boot the application */
+			if (bootloader_boot(i) != OK) {
+				ret = -1;
+			}
+		}
+	}
+
 	return ret;
 }
 
@@ -1326,6 +1278,31 @@ OREOLED::bootloader_fw_checksum(void)
 }
 
 int
+OREOLED::bootloader_flash_all(bool force_update)
+{
+	int ret = -1;
+
+	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+		if (_healthy[i] && _in_boot[i]) {
+			int result;
+
+			if (force_update) {
+				result = bootloader_flash(i);
+			} else if (bootloader_app_checksum(i) != bootloader_fw_checksum()) {
+				/* only flash LEDs with an old version of the applictioon */
+				result = bootloader_flash(i);
+			}
+
+			if (result != OK) {
+				ret = -1;
+			}
+		}
+	}
+
+	return ret;
+}
+
+int
 OREOLED::bootloader_coerce_healthy(void)
 {
 	int ret = -1;
@@ -1343,6 +1320,20 @@ OREOLED::bootloader_coerce_healthy(void)
 	}
 
 	return ret;
+}
+
+void
+OREOLED::bootloader_cmd_add_checksum(oreoled_cmd_t* cmd)
+{
+	if (cmd->num_bytes == 0 || cmd->num_bytes >= OREOLED_CMD_LENGTH_MAX) {
+		return;
+	}
+
+	/* write a basic 8-bit XOR checksum into the last byte of the command bytes array*/
+	uint8_t checksum_idx = cmd->num_bytes - 1;
+	for (uint8_t i = 0; i < checksum_idx; i++) {
+		cmd->buff[checksum_idx] ^= cmd->buff[i];
+	}
 }
 
 int

--- a/src/drivers/oreoled/oreoled.cpp
+++ b/src/drivers/oreoled/oreoled.cpp
@@ -52,8 +52,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <ctype.h>
-#include <sys/stat.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/wqueue.h>
@@ -71,8 +69,8 @@
 #define OREOLED_NUM_LEDS		4			///< maximum number of LEDs the oreo led driver can support
 #define OREOLED_BASE_I2C_ADDR	0x68		///< base i2c address (7-bit)
 #define OPEOLED_I2C_RETRYCOUNT  2           ///< i2c retry count
-#define OREOLED_TIMEOUT_USEC	2000000U	///< timeout looking for oreoleds 2 seconds after startup
-#define OREOLED_GENERALCALL_US	4000000U	///< general call sent every 4 seconds
+#define OREOLED_TIMEOUT_USEC	1000000U	///< timeout looking for oreoleds 1 second after startup
+#define OREOLED_GENERALCALL_US	2000000U	///< general call sent every 2 seconds
 #define OREOLED_GENERALCALL_CMD	0x00		///< general call command sent at regular intervals
 
 #define OREOLED_STARTUP_INTERVAL_US		(1000000U / 10U)	///< time in microseconds, run at 10hz
@@ -80,10 +78,13 @@
 
 #define OREOLED_CMD_QUEUE_SIZE	10		///< up to 10 messages can be queued up to send to the LEDs
 
+/* magic number used to verify the software reset is valid */
+#define OEROLED_RESET_NONCE				0x2A
+
 class OREOLED : public device::I2C
 {
 public:
-	OREOLED(int bus, int i2c_addr, bool autoupdate, bool alwaysupdate);
+	OREOLED(int bus, int i2c_addr);
 	virtual ~OREOLED();
 
 	virtual int		init();
@@ -96,9 +97,6 @@ public:
 
 	/* send cmd to an LEDs (used for testing only) */
 	int				send_cmd(oreoled_cmd_t sb);
-
-	/* returns true once the driver finished bootloading and ready for commands */
-	bool			is_ready();
 
 private:
 
@@ -122,41 +120,17 @@ private:
 	 */
 	void			cycle();
 
-	void			run_initial_discovery(void);
-	void			run_updates(void);
+	void			startup_discovery(void);
 
-	void			bootloader_update_application(bool force_update);
-	int				bootloader_app_reset(int led_num);
-	int				bootloader_app_reset_all(void);
-	int				bootloader_app_ping(int led_num);
-	uint16_t		bootloader_inapp_checksum(int led_num);
-	int				bootloader_ping(int led_num);
-	uint8_t			bootloader_version(int led_num);
-	uint16_t		bootloader_app_version(int led_num);
-	uint16_t		bootloader_app_checksum(int led_num);
-	int				bootloader_set_colour(int led_num, uint8_t red, uint8_t green);
-	int				bootloader_flash(int led_num);
-	int				bootloader_flash_all(bool force_update);
-	int				bootloader_boot(int led_num);
-	int				bootloader_boot_all(void);
-	uint16_t		bootloader_fw_checksum(void);
-	int				bootloader_coerce_healthy(void);
-	void			bootloader_cmd_add_checksum(oreoled_cmd_t* cmd);
+	uint8_t			cmd_add_checksum(oreoled_cmd_t *cmd);
 
 	/* internal variables */
 	work_s			_work;							///< work queue for scheduling reads
 	bool			_healthy[OREOLED_NUM_LEDS];		///< health of each LED
-	bool			_in_boot[OREOLED_NUM_LEDS];		///< true for each LED that is in bootloader mode
 	uint8_t			_num_healthy;					///< number of healthy LEDs
-	uint8_t			_num_inboot;					///< number of LEDs in bootloader
 	RingBuffer		*_cmd_queue;					///< buffer of commands to send to LEDs
 	uint64_t		_last_gencall;
 	uint64_t		_start_time;					///< system time we first attempt to communicate with battery
-	bool			_autoupdate;					///< true if the driver should update all LEDs
-	bool			_alwaysupdate;					///< true if the driver should update all LEDs
-	bool			_is_bootloading;				///< true if a bootloading operation is in progress
-	bool			_is_ready;						///< set to true once the driver has completly initialised
-	uint16_t		_fw_checksum;					///< the current 16bit XOR checksum of the built in oreoled firmware binary
 
 	/* performance checking */
 	perf_counter_t      _call_perf;
@@ -177,18 +151,12 @@ void oreoled_usage();
 extern "C" __EXPORT int oreoled_main(int argc, char *argv[]);
 
 /* constructor */
-OREOLED::OREOLED(int bus, int i2c_addr, bool autoupdate, bool alwaysupdate) :
+OREOLED::OREOLED(int bus, int i2c_addr) :
 	I2C("oreoled", OREOLED0_DEVICE_PATH, bus, i2c_addr, 100000),
 	_work{},
 	_num_healthy(0),
-	_num_inboot(0),
 	_cmd_queue(nullptr),
 	_last_gencall(0),
-	_autoupdate(autoupdate),
-	_alwaysupdate(alwaysupdate),
-	_is_bootloading(false),
-	_is_ready(false),
-	_fw_checksum(0x0000),
 	_call_perf(perf_alloc(PC_ELAPSED, "oreoled_call")),
 	_gcall_perf(perf_alloc(PC_ELAPSED, "oreoled_gcall")),
 	_probe_perf(perf_alloc(PC_ELAPSED, "oreoled_probe")),
@@ -197,9 +165,6 @@ OREOLED::OREOLED(int bus, int i2c_addr, bool autoupdate, bool alwaysupdate) :
 {
 	/* initialise to unhealthy */
 	memset(_healthy, 0, sizeof(_healthy));
-
-	/* initialise to in application */
-	memset(_in_boot, 0, sizeof(_in_boot));
 
 	/* capture startup time */
 	_start_time = hrt_absolute_time();
@@ -316,18 +281,11 @@ OREOLED::cycle()
 
 	/* during startup period keep searching for unhealthy LEDs */
 	if (!startup_timeout && _num_healthy < OREOLED_NUM_LEDS) {
-		run_initial_discovery();
+		startup_discovery();
 
 		/* schedule another attempt in 0.1 sec */
 		work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this,
 			   USEC2TICK(OREOLED_STARTUP_INTERVAL_US));
-		return;
-	} else if (_alwaysupdate || _autoupdate || _num_inboot || _is_ready) {
-		run_updates();
-
-		/* schedule another attempt in 20mS */
-		work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this,
-			   USEC2TICK(OREOLED_UPDATE_INTERVAL_US));
 		return;
 	}
 
@@ -344,12 +302,8 @@ OREOLED::cycle()
 			/* set I2C address */
 			set_address(OREOLED_BASE_I2C_ADDR + next_cmd.led_num);
 
-			/* Calculate XOR CRC and append to the i2c write data */
-			uint8_t next_cmd_xor = OREOLED_BASE_I2C_ADDR + next_cmd.led_num;
-			for (uint8_t i = 0; i < next_cmd.num_bytes; i++) {
-				next_cmd_xor ^= next_cmd.buff[i];
-			}
-			next_cmd.buff[next_cmd.num_bytes++] = next_cmd_xor;
+			/* Calculate XOR checksum and append to the i2c write data */
+			uint8_t next_cmd_xor = cmd_add_checksum(&next_cmd);
 
 			/* send I2C command with a retry limit */
 			uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
@@ -372,7 +326,7 @@ OREOLED::cycle()
 	}
 
 	/* send general call every 4 seconds, if we aren't bootloading*/
-	if (!_is_bootloading && ((now - _last_gencall) > OREOLED_GENERALCALL_US)) {
+	if ((now - _last_gencall) > OREOLED_GENERALCALL_US) {
 		perf_begin(_gcall_perf);
 		send_general_call();
 		perf_end(_gcall_perf);
@@ -384,57 +338,41 @@ OREOLED::cycle()
 }
 
 void
-OREOLED::run_initial_discovery(void)
+OREOLED::startup_discovery(void)
 {
-	/* prepare command to turn off LED */
-	/* add two bytes of pre-amble to for higher signal to noise ratio */
-	uint8_t msg[] = {0xAA, 0x55, OREOLED_PATTERN_OFF, 0x00};
+	oreoled_cmd_t cmd;
+	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
 
 	/* attempt to contact each unhealthy LED */
 	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
 		if (!_healthy[i]) {
 			perf_begin(_probe_perf);
 
+			/* prepare command to turn off LED */
+			cmd.led_num = i;
+			cmd.buff[0] = 0xAA;
+			cmd.buff[1] = 0x55;
+			cmd.buff[2] = OREOLED_PATTERN_OFF;
+			cmd.num_bytes = 3;
+			uint8_t cmd_checksum = cmd_add_checksum(&cmd);
+
 			/* set I2C address */
-			set_address(OREOLED_BASE_I2C_ADDR + i);
-
-			/* Calculate XOR CRC and append to the i2c write data */
-			msg[sizeof(msg) - 1] = OREOLED_BASE_I2C_ADDR + i;
-
-			for (uint8_t j = 0; j < sizeof(msg) - 1; j++) {
-				msg[sizeof(msg) - 1] ^= msg[j];
-			}
+			set_address(OREOLED_BASE_I2C_ADDR + cmd.led_num);
 
 			/* send I2C command */
-			uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-			if (transfer(msg, sizeof(msg), reply, 3) == OK) {
-				if (reply[1] == OREOLED_BASE_I2C_ADDR + i &&
-				    reply[2] == msg[sizeof(msg) - 1]) {
-					log("oreoled %u ok - in bootloader", (unsigned)i);
-					_healthy[i] = true;
-					_num_healthy++;
-
-					/* If slaves are in application record that so we can reset if we need to bootload */
-					/* This additional check is required for LED firmwares below v1.3 and can be
-					   deprecated once all LEDs in the wild have firmware >= v1.3 */
-					if(bootloader_ping(i) == OK) {
-						_in_boot[i] = true;
-						_num_inboot++;
-					}
-
+			if (transfer(cmd.buff, cmd.num_bytes, reply, 3) == OK) {
 				/* Check for a reply with a checksum offset of 1,
 				   which indicates a response from firmwares >= 1.3 */
-				} else if (reply[1] == OREOLED_BASE_I2C_ADDR + i &&
-				    reply[2] == msg[sizeof(msg) - 1] + 1) {
+				if (reply[1] == OREOLED_BASE_I2C_ADDR + cmd.led_num &&
+				    reply[2] == (cmd_checksum + 1)) {
 					log("oreoled %u ok - in application", (unsigned)i);
 					_healthy[i] = true;
 					_num_healthy++;
-
 				} else {
-					log("oreo reply errors: %u", (unsigned)_reply_errors);
+					warnx("startup response  ADDR: 0x%x expected 0x%x", reply[1], cmd.led_num);
+					warnx("startup response   CMD: 0x%x expected 0x%x", reply[2], (cmd_checksum + 1));
 					perf_count(_reply_errors);
 				}
-
 			} else {
 				perf_count(_comms_errors);
 			}
@@ -444,896 +382,22 @@ OREOLED::run_initial_discovery(void)
 	}
 }
 
-void
-OREOLED::run_updates(void)
-{
-	if (_alwaysupdate) {
-		bootloader_update_application(true);
-		_alwaysupdate = false;
-	} else if (_autoupdate) {
-		bootloader_update_application(false);
-		_autoupdate = false;
-	} else if (_num_inboot > 0) {
-		bootloader_boot_all();
-		bootloader_coerce_healthy();
-		_num_inboot = 0;
-	} else if (!_is_ready) {
-		/* indicate a ready state since startup has finished */
-		_is_ready = true;
-	}
-}
-
-void
-OREOLED::bootloader_update_application(bool force_update)
-{
-	/* check booted oreoleds to see if the app can report it's checksum (release versions >= v1.2) */
-	if(!force_update) {
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i] && !_in_boot[i]) {
-				/* put any out of date oreoleds into bootloader mode */
-				/* being in bootloader mode signals to be code below that the will likey need updating */
-				if (bootloader_inapp_checksum(i) != bootloader_fw_checksum()) {
-					bootloader_app_reset(i);
-				}
-			}
-		}
-	}
-
-	/* reset all healthy oreoleds if the number of outdated oreoled's is > 0 */
-	/* this is done for consistency, so if only one oreoled is updating, all LEDs show the same behaviour */
-	/* otherwise a single oreoled could appear broken or failed. */
-	if (_num_inboot > 0 || force_update) {
-		bootloader_app_reset_all();
-
-		/* update each outdated and healthy LED in bootloader mode */
-		bootloader_flash_all(force_update);
-
-		/* boot each healthy LED */
-		bootloader_boot_all();
-
-		/* coerce LEDs with startup issues to be healthy again */
-		bootloader_coerce_healthy();
-	}
-}
-
-int
-OREOLED::bootloader_app_reset(int led_num)
-{
-	_is_bootloading = true;
-	oreoled_cmd_t boot_cmd;
-	boot_cmd.led_num = led_num;
-
-	int ret = -1;
-
-	/* Set the current address */
-	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
-
-	/* send a reset */
-	boot_cmd.buff[0] = OREOLED_PATTERN_PARAMUPDATE;
-	boot_cmd.buff[1] = OREOLED_PARAM_RESET;
-	boot_cmd.buff[2] = OEROLED_RESET_NONCE;
-	boot_cmd.buff[3] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-	boot_cmd.num_bytes = 4;
-	bootloader_cmd_add_checksum(&boot_cmd);
-
-	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-
-	/* send I2C command with a retry limit */
-	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
-		if (transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 3) == OK) {
-			if (reply[1] == (OREOLED_BASE_I2C_ADDR + boot_cmd.led_num) &&
-			    reply[2] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-				/* slave returned a valid response */
-				ret = OK;
-				/* set this LED as being in boot mode now */
-				_in_boot[led_num] = true;
-				_num_inboot++;
-				break;
-			}
-		}
-	}
-
-	/* Allow time for the LED to reboot */
-	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
-	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
-	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
-	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
-
-	_is_bootloading = false;
-	return ret;
-}
-
-int
-OREOLED::bootloader_app_reset_all(void)
-{
-	int ret = OK;
-
-	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-		if (_healthy[i] && !_in_boot[i]) {
-			/* reset the LED if it's not in the bootloader */
-			/* (this happens during a pixhawk OTA update, since the LEDs stay powered) */
-			if (bootloader_app_reset(i) != OK) {
-				ret = -1;
-			}
-		}
-	}
-
-	return ret;
-}
-
-int
-OREOLED::bootloader_app_ping(int led_num)
-{
-	oreoled_cmd_t boot_cmd;
-	boot_cmd.led_num = led_num;
-
-	int ret = -1;
-
-	/* Set the current address */
-	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
-
-	/* send a pattern off command */
-	boot_cmd.buff[0] = 0xAA;
-	boot_cmd.buff[1] = 0x55;
-	boot_cmd.buff[2] = OREOLED_PATTERN_OFF;
-	boot_cmd.buff[3] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-	boot_cmd.num_bytes = 4;
-	bootloader_cmd_add_checksum(&boot_cmd);
-
-	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-
-	/* send I2C command with a retry limit */
-	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
-		if (transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 3) == OK) {
-			if (reply[1] == (OREOLED_BASE_I2C_ADDR + boot_cmd.led_num) &&
-			    reply[2] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-				/* slave returned a valid response */
-				ret = OK;
-				break;
-			}
-		}
-	}
-
-	return ret;
-}
-
-uint16_t
-OREOLED::bootloader_inapp_checksum(int led_num)
-{
-	_is_bootloading = true;
-	oreoled_cmd_t boot_cmd;
-	boot_cmd.led_num = led_num;
-
-	uint16_t ret = 0x0000;
-
-	/* Set the current address */
-	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
-
-	boot_cmd.buff[0] = OREOLED_PATTERN_PARAMUPDATE;
-	boot_cmd.buff[1] = OREOLED_PARAM_APP_CHECKSUM;
-	boot_cmd.buff[2] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-	boot_cmd.num_bytes = 3;
-	bootloader_cmd_add_checksum(&boot_cmd);
-
-	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-
-	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
-		/* Send the I2C Write+Read */
-		memset(reply, 0, sizeof(reply));
-		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 6);
-
-		/* Check the response */
-		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
-		    reply[2] == OREOLED_PARAM_APP_CHECKSUM &&
-		    reply[5] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-			warnx("bl app checksum OK from LED %i", boot_cmd.led_num);
-			warnx("bl app checksum msb: 0x%x", reply[3]);
-			warnx("bl app checksum lsb: 0x%x", reply[4]);
-			ret = ((reply[3] << 8) | reply[4]);
-			break;
-
-		} else {
-			warnx("bl app checksum FAIL from LED %i", boot_cmd.led_num);
-			warnx("bl app checksum response  ADDR: 0x%x", reply[1]);
-			warnx("bl app checksum response   CMD: 0x%x", reply[2]);
-			warnx("bl app checksum response VER H: 0x%x", reply[3]);
-			warnx("bl app checksum response VER L: 0x%x", reply[4]);
-			warnx("bl app checksum response   XOR: 0x%x", reply[5]);
-
-			if (retry > 1) {
-				warnx("bl app checksum retrying LED %i", boot_cmd.led_num);
-
-			} else {
-				warnx("bl app checksum failed on LED %i", boot_cmd.led_num);
-				break;
-			}
-		}
-	}
-
-	_is_bootloading = false;
-	return ret;
-}
-
-int
-OREOLED::bootloader_ping(int led_num)
-{
-	_is_bootloading = true;
-	oreoled_cmd_t boot_cmd;
-	boot_cmd.led_num = led_num;
-
-	int ret = -1;
-
-	/* Set the current address */
-	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
-
-	boot_cmd.buff[0] = OREOLED_BOOT_CMD_PING;
-	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-	boot_cmd.num_bytes = 2;
-	bootloader_cmd_add_checksum(&boot_cmd);
-
-	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-
-	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
-		/* Send the I2C Write+Read */
-		memset(reply, 0, sizeof(reply));
-		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 5);
-
-		/* Check the response */
-		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
-		    reply[2] == OREOLED_BOOT_CMD_PING &&
-		    reply[3] == OREOLED_BOOT_CMD_PING_NONCE &&
-		    reply[4] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-			warnx("bl ping OK from LED %i", boot_cmd.led_num);
-			ret = OK;
-			break;
-
-		} else {
-			warnx("bl ping FAIL from LED %i", boot_cmd.led_num);
-			warnx("bl ping response  ADDR: 0x%x", reply[1]);
-			warnx("bl ping response   CMD: 0x%x", reply[2]);
-			warnx("bl ping response NONCE: 0x%x", reply[3]);
-			warnx("bl ping response   XOR: 0x%x", reply[4]);
-
-			if (retry > 1) {
-				warnx("bl ping retrying LED %i", boot_cmd.led_num);
-
-			} else {
-				warnx("bl ping failed on LED %i", boot_cmd.led_num);
-				break;
-			}
-		}
-	}
-
-	_is_bootloading = false;
-	return ret;
-}
-
 uint8_t
-OREOLED::bootloader_version(int led_num)
+OREOLED::cmd_add_checksum(oreoled_cmd_t *cmd)
 {
-	_is_bootloading = true;
-	oreoled_cmd_t boot_cmd;
-	boot_cmd.led_num = led_num;
-
-	uint8_t ret = 0x00;
-
-	/* Set the current address */
-	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
-
-	boot_cmd.buff[0] = OREOLED_BOOT_CMD_BL_VER;
-	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-	boot_cmd.num_bytes = 2;
-	bootloader_cmd_add_checksum(&boot_cmd);
-
-	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-
-	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
-		/* Send the I2C Write+Read */
-		memset(reply, 0, sizeof(reply));
-		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 5);
-
-		/* Check the response */
-		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
-		    reply[2] == OREOLED_BOOT_CMD_BL_VER &&
-		    reply[3] == OREOLED_BOOT_SUPPORTED_VER &&
-		    reply[4] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-			warnx("bl ver from LED %i = %i", boot_cmd.led_num, reply[3]);
-			ret = reply[3];
-			break;
-
-		} else {
-			warnx("bl ver response  ADDR: 0x%x", reply[1]);
-			warnx("bl ver response   CMD: 0x%x", reply[2]);
-			warnx("bl ver response   VER: 0x%x", reply[3]);
-			warnx("bl ver response   XOR: 0x%x", reply[4]);
-
-			if (retry > 1) {
-				warnx("bl ver retrying LED %i", boot_cmd.led_num);
-
-			} else {
-				warnx("bl ver failed on LED %i", boot_cmd.led_num);
-				break;
-			}
-		}
-	}
-
-	_is_bootloading = false;
-	return ret;
-}
-
-uint16_t
-OREOLED::bootloader_app_version(int led_num)
-{
-	_is_bootloading = true;
-	oreoled_cmd_t boot_cmd;
-	boot_cmd.led_num = led_num;
-
-	uint16_t ret = 0x0000;
-
-	/* Set the current address */
-	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
-
-	boot_cmd.buff[0] = OREOLED_BOOT_CMD_APP_VER;
-	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-	boot_cmd.num_bytes = 2;
-	bootloader_cmd_add_checksum(&boot_cmd);
-
-	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-
-	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
-		/* Send the I2C Write+Read */
-		memset(reply, 0, sizeof(reply));
-		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 6);
-
-		/* Check the response */
-		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
-		    reply[2] == OREOLED_BOOT_CMD_APP_VER &&
-		    reply[5] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-			warnx("bl app version OK from LED %i", boot_cmd.led_num);
-			warnx("bl app version msb: 0x%x", reply[3]);
-			warnx("bl app version lsb: 0x%x", reply[4]);
-			ret = ((reply[3] << 8) | reply[4]);
-			break;
-
-		} else {
-			warnx("bl app version FAIL from LED %i", boot_cmd.led_num);
-			warnx("bl app version response  ADDR: 0x%x", reply[1]);
-			warnx("bl app version response   CMD: 0x%x", reply[2]);
-			warnx("bl app version response VER H: 0x%x", reply[3]);
-			warnx("bl app version response VER L: 0x%x", reply[4]);
-			warnx("bl app version response   XOR: 0x%x", reply[5]);
-
-			if (retry > 1) {
-				warnx("bl app version retrying LED %i", boot_cmd.led_num);
-
-			} else {
-				warnx("bl app version failed on LED %i", boot_cmd.led_num);
-				break;
-			}
-		}
-	}
-
-	_is_bootloading = false;
-	return ret;
-}
-
-uint16_t
-OREOLED::bootloader_app_checksum(int led_num)
-{
-	_is_bootloading = true;
-	oreoled_cmd_t boot_cmd;
-	boot_cmd.led_num = led_num;
-
-	uint16_t ret = 0x0000;
-
-	/* Set the current address */
-	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
-
-	boot_cmd.buff[0] = OREOLED_BOOT_CMD_APP_CRC;
-	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-	boot_cmd.num_bytes = 2;
-	bootloader_cmd_add_checksum(&boot_cmd);
-
-	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-
-	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
-		/* Send the I2C Write+Read */
-		memset(reply, 0, sizeof(reply));
-		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 6);
-
-		/* Check the response */
-		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
-		    reply[2] == OREOLED_BOOT_CMD_APP_CRC &&
-		    reply[5] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-			warnx("bl app checksum OK from LED %i", boot_cmd.led_num);
-			warnx("bl app checksum msb: 0x%x", reply[3]);
-			warnx("bl app checksum lsb: 0x%x", reply[4]);
-			ret = ((reply[3] << 8) | reply[4]);
-			break;
-
-		} else {
-			warnx("bl app checksum FAIL from LED %i", boot_cmd.led_num);
-			warnx("bl app checksum response  ADDR: 0x%x", reply[1]);
-			warnx("bl app checksum response   CMD: 0x%x", reply[2]);
-			warnx("bl app checksum response VER H: 0x%x", reply[3]);
-			warnx("bl app checksum response VER L: 0x%x", reply[4]);
-			warnx("bl app checksum response   XOR: 0x%x", reply[5]);
-
-			if (retry > 1) {
-				warnx("bl app checksum retrying LED %i", boot_cmd.led_num);
-
-			} else {
-				warnx("bl app checksum failed on LED %i", boot_cmd.led_num);
-				break;
-			}
-		}
-	}
-
-	_is_bootloading = false;
-	return ret;
-}
-
-int
-OREOLED::bootloader_set_colour(int led_num, uint8_t red, uint8_t green)
-{
-	_is_bootloading = true;
-	oreoled_cmd_t boot_cmd;
-	boot_cmd.led_num = led_num;
-
-	int ret = -1;
-
-	/* Set the current address */
-	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
-
-	boot_cmd.buff[0] = OREOLED_BOOT_CMD_SET_COLOUR;
-	boot_cmd.buff[1] = red;
-	boot_cmd.buff[2] = green;
-	boot_cmd.buff[3] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-	boot_cmd.num_bytes = 4;
-	bootloader_cmd_add_checksum(&boot_cmd);
-
-	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-
-	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
-		/* Send the I2C Write+Read */
-		memset(reply, 0, sizeof(reply));
-		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 4);
-
-		/* Check the response */
-		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
-		    reply[2] == OREOLED_BOOT_CMD_SET_COLOUR &&
-		    reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-			warnx("bl set colour OK from LED %i", boot_cmd.led_num);
-			ret = OK;
-			break;
-
-		} else {
-			warnx("bl set colour FAIL from LED %i", boot_cmd.led_num);
-			warnx("bl set colour response  ADDR: 0x%x", reply[1]);
-			warnx("bl set colour response   CMD: 0x%x", reply[2]);
-			warnx("bl set colour response   XOR: 0x%x", reply[3]);
-
-			if (retry > 1) {
-				warnx("bl app colour retrying LED %i", boot_cmd.led_num);
-
-			} else {
-				warnx("bl app colour failed on LED %i", boot_cmd.led_num);
-				break;
-			}
-		}
-	}
-
-	_is_bootloading = false;
-	return ret;
-}
-
-int
-OREOLED::bootloader_flash(int led_num)
-{
-	_is_bootloading = true;
-	oreoled_cmd_t boot_cmd;
-	boot_cmd.led_num = led_num;
-
-	/* Open the bootloader file */
-	int fd = ::open(OREOLED_FW_FILE, O_RDONLY);
-
-	/* check for error opening the file */
-	if (fd < 0) {
-		return -1;
-	}
-
-	struct stat s;
-
-	/* attempt to stat the file */
-	if (stat(OREOLED_FW_FILE, &s) != 0) {
-		::close(fd);
-		return -1;
-	}
-
-	uint16_t fw_length = s.st_size - OREOLED_FW_FILE_HEADER_LENGTH;
-
-	/* sanity-check file size */
-	if (fw_length > OREOLED_FW_FILE_SIZE_LIMIT) {
-		::close(fd);
-		return -1;
-	}
-
-	uint8_t *buf = new uint8_t[s.st_size];
-
-	/* check that the buffer has been allocated */
-	if (buf == NULL) {
-		::close(fd);
-		return -1;
-	}
-
-	/* check that the firmware can be read into the buffer */
-	if (::read(fd, buf, s.st_size) != s.st_size) {
-		::close(fd);
-		delete[] buf;
-		return -1;
-	}
-
-	::close(fd);
-
-	/* Grab the version bytes from the binary */
-	uint8_t version_major = buf[0];
-	uint8_t version_minor = buf[1];
-
-	/* calculate flash pages (rounded up to nearest integer) */
-	uint8_t flash_pages = ((fw_length + 64 - 1) / 64);
-
-	/* Set the current address */
-	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
-
-	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-
-	/* Loop through flash pages */
-	for (uint8_t page_idx = 0; page_idx < flash_pages; page_idx++) {
-
-		/* Send the first half of the 64 byte flash page */
-		memset(boot_cmd.buff, 0, sizeof(boot_cmd.buff));
-		boot_cmd.buff[0] = OREOLED_BOOT_CMD_WRITE_FLASH_A;
-		boot_cmd.buff[1] = page_idx;
-		memcpy(boot_cmd.buff + 2, buf + (page_idx * 64) + OREOLED_FW_FILE_HEADER_LENGTH, 32);
-		boot_cmd.buff[32 + 2] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-		boot_cmd.num_bytes = 32 + 3;
-		bootloader_cmd_add_checksum(&boot_cmd);
-
-		for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
-			/* Send the I2C Write+Read */
-			memset(reply, 0, sizeof(reply));
-			transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 4);
-
-			/* Check the response */
-			if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
-			    reply[2] == OREOLED_BOOT_CMD_WRITE_FLASH_A &&
-			    reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-				warnx("bl flash %ia OK for LED %i", page_idx, boot_cmd.led_num);
-				break;
-
-			} else {
-				warnx("bl flash %ia FAIL for LED %i", page_idx, boot_cmd.led_num);
-				warnx("bl flash %ia response ADDR: 0x%x", page_idx, reply[1]);
-				warnx("bl flash %ia response  CMD: 0x%x", page_idx, reply[2]);
-				warnx("bl flash %ia response  XOR: 0x%x", page_idx, reply[3]);
-
-				if (retry > 1) {
-					warnx("bl flash %ia retrying LED %i", page_idx, boot_cmd.led_num);
-
-				} else {
-					warnx("bl flash %ia failed on LED %i", page_idx, boot_cmd.led_num);
-					delete[] buf;
-					return -1;
-				}
-			}
-		}
-
-		/* Send the second half of the 64 byte flash page */
-		memset(boot_cmd.buff, 0, sizeof(boot_cmd.buff));
-		boot_cmd.buff[0] = OREOLED_BOOT_CMD_WRITE_FLASH_B;
-		memcpy(boot_cmd.buff + 1, buf + (page_idx * 64) + 32 + OREOLED_FW_FILE_HEADER_LENGTH, 32);
-		boot_cmd.buff[32 + 1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-		boot_cmd.num_bytes = 32 + 2;
-		bootloader_cmd_add_checksum(&boot_cmd);
-
-		for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
-			/* Send the I2C Write+Read */
-			memset(reply, 0, sizeof(reply));
-			transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 4);
-
-			/* Check the response */
-			if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
-			    reply[2] == OREOLED_BOOT_CMD_WRITE_FLASH_B &&
-			    reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-				warnx("bl flash %ib OK for LED %i", page_idx, boot_cmd.led_num);
-				break;
-
-			} else {
-				warnx("bl flash %ib FAIL for LED %i", page_idx, boot_cmd.led_num);
-				warnx("bl flash %ib response ADDR: 0x%x", page_idx, reply[1]);
-				warnx("bl flash %ib response  CMD: 0x%x", page_idx, reply[2]);
-				warnx("bl flash %ib response  XOR: 0x%x", page_idx, reply[3]);
-
-				if (retry > 1) {
-					warnx("bl flash %ib retrying LED %i", page_idx, boot_cmd.led_num);
-
-				} else {
-					errx(1, "bl flash %ib failed on LED %i", page_idx, boot_cmd.led_num);
-					delete[] buf;
-					return -1;
-				}
-			}
-		}
-
-		/* Sleep to allow flash to write */
-		/* Wait extra long on the first write, to allow time for EEPROM updates */
-		if (page_idx == 0) {
-			usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
-
-		} else {
-			usleep(OREOLED_BOOT_FLASH_WAITMS * 1000);
-		}
-	}
-
-	uint16_t app_checksum = bootloader_fw_checksum();
-
-	/* Flash writes must have succeeded so finalise the flash */
-	boot_cmd.buff[0] = OREOLED_BOOT_CMD_FINALISE_FLASH;
-	boot_cmd.buff[1] = version_major;
-	boot_cmd.buff[2] = version_minor;
-	boot_cmd.buff[3] = (uint8_t)(fw_length >> 8);
-	boot_cmd.buff[4] = (uint8_t)(fw_length & 0xFF);
-	boot_cmd.buff[5] = (uint8_t)(app_checksum >> 8);
-	boot_cmd.buff[6] = (uint8_t)(app_checksum & 0xFF);
-	boot_cmd.buff[7] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-	boot_cmd.num_bytes = 8;
-	bootloader_cmd_add_checksum(&boot_cmd);
-
-	/* Try to finalise for twice the amount of normal retries */
-	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES * 2; retry > 0; retry--) {
-		/* Send the I2C Write */
-		memset(reply, 0, sizeof(reply));
-		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 4);
-
-		/* Check the response */
-		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
-		    reply[2] == OREOLED_BOOT_CMD_FINALISE_FLASH &&
-		    reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-			warnx("bl finalise OK from LED %i", boot_cmd.led_num);
-			break;
-
-		} else {
-			warnx("bl finalise response  ADDR: 0x%x", reply[1]);
-			warnx("bl finalise response   CMD: 0x%x", reply[2]);
-			warnx("bl finalise response   XOR: 0x%x", reply[3]);
-
-			if (retry > 1) {
-				warnx("bl finalise retrying LED %i", boot_cmd.led_num);
-
-			} else {
-				warnx("bl finalise failed on LED %i", boot_cmd.led_num);
-				delete[] buf;
-				return -1;
-			}
-		}
-	}
-
-	/* allow time for flash to finalise */
-	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
-	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
-
-	/* clean up file buffer */
-	delete[] buf;
-
-	_is_bootloading = false;
-	return 1;
-}
-
-int
-OREOLED::bootloader_boot(int led_num)
-{
-	_is_bootloading = true;
-	oreoled_cmd_t boot_cmd;
-	boot_cmd.led_num = led_num;
-
-	int ret = -1;
-
-	/* Set the current address */
-	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
-
-	boot_cmd.buff[0] = OREOLED_BOOT_CMD_BOOT_APP;
-	boot_cmd.buff[1] = OREOLED_BOOT_CMD_BOOT_NONCE;
-	boot_cmd.buff[2] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
-	boot_cmd.num_bytes = 3;
-	bootloader_cmd_add_checksum(&boot_cmd);
-
-	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
-		/* Send the I2C Write */
-		uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
-		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 4);
-
-		/* Check the response */
-		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
-		    reply[2] == OREOLED_BOOT_CMD_BOOT_APP &&
-		    reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-			warnx("bl boot OK from LED %i", boot_cmd.led_num);
-			/* decrement the inboot counter so we don't get confused */
-			_in_boot[led_num] = false;
-			_num_inboot--;
-			ret = OK;
-			break;
-
-		} else if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
-			   reply[2] == OREOLED_BOOT_CMD_BOOT_NONCE &&
-			   reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
-			warnx("bl boot error from LED %i: no app", boot_cmd.led_num);
-			break;
-
-		} else {
-			warnx("bl boot response  ADDR: 0x%x", reply[1]);
-			warnx("bl boot response   CMD: 0x%x", reply[2]);
-			warnx("bl boot response   XOR: 0x%x", reply[3]);
-
-			if (retry > 1) {
-				warnx("bl boot retrying LED %i", boot_cmd.led_num);
-
-			} else {
-				warnx("bl boot failed on LED %i", boot_cmd.led_num);
-				break;
-			}
-		}
-	}
-
-	/* allow time for the LEDs to boot */
-	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
-	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
-	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
-	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
-
-	_is_bootloading = false;
-	return ret;
-}
-
-int
-OREOLED::bootloader_boot_all(void) {
-	int ret = OK;
-
-	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-		if (_healthy[i] && _in_boot[i]) {
-			/* boot the application */
-			if (bootloader_boot(i) != OK) {
-				ret = -1;
-			}
-		}
-	}
-
-	return ret;
-}
-
-uint16_t
-OREOLED::bootloader_fw_checksum(void)
-{
-	/* Calculate the 16 bit XOR checksum of the firmware on the first call of this function */
-	if (_fw_checksum == 0x0000) {
-		/* Open the bootloader file */
-		int fd = ::open(OREOLED_FW_FILE, O_RDONLY);
-
-		/* check for error opening the file */
-		if (fd < 0) {
-			return -1;
-		}
-
-		struct stat s;
-
-		/* attempt to stat the file */
-		if (stat(OREOLED_FW_FILE, &s) != 0) {
-			::close(fd);
-			return -1;
-		}
-
-		uint16_t fw_length = s.st_size - OREOLED_FW_FILE_HEADER_LENGTH;
-
-		/* sanity-check file size */
-		if (fw_length > OREOLED_FW_FILE_SIZE_LIMIT) {
-			::close(fd);
-			return -1;
-		}
-
-		uint8_t *buf = new uint8_t[s.st_size];
-
-		/* check that the buffer has been allocated */
-		if (buf == NULL) {
-			::close(fd);
-			return -1;
-		}
-
-		/* check that the firmware can be read into the buffer */
-		if (::read(fd, buf, s.st_size) != s.st_size) {
-			::close(fd);
-			delete[] buf;
-			return -1;
-		}
-
-		::close(fd);
-
-		/* Calculate a 16 bit XOR checksum of the flash */
-		/* Skip the first two bytes which are the version information, plus
-		   the next two bytes which are modified by the bootloader */
-		uint16_t app_checksum = 0x0000;
-
-		for (uint16_t j = 2 + OREOLED_FW_FILE_HEADER_LENGTH; j < s.st_size; j += 2) {
-			app_checksum ^= (buf[j] << 8) | buf[j + 1];
-		}
-
-		delete[] buf;
-
-		warnx("fw length = %i", fw_length);
-		warnx("fw checksum = %i", app_checksum);
-
-		/* Store the checksum so it's only calculated once */
-		_fw_checksum = app_checksum;
-	}
-
-	return _fw_checksum;
-}
-
-int
-OREOLED::bootloader_flash_all(bool force_update)
-{
-	int ret = -1;
-
-	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-		if (_healthy[i] && _in_boot[i]) {
-			int result;
-
-			if (force_update) {
-				result = bootloader_flash(i);
-			} else if (bootloader_app_checksum(i) != bootloader_fw_checksum()) {
-				/* only flash LEDs with an old version of the applictioon */
-				result = bootloader_flash(i);
-			}
-
-			if (result != OK) {
-				ret = -1;
-			}
-		}
-	}
-
-	return ret;
-}
-
-int
-OREOLED::bootloader_coerce_healthy(void)
-{
-	int ret = -1;
-
-	/* check each unhealthy LED */
-	/* this re-checks "unhealthy" LEDs as they can sometimes power up with the wrong ID, */
-	/*  but will have the correct ID once they jump to the application and be healthy again */
-	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-		if (!_healthy[i] && bootloader_app_ping(i) == OK) {
-			/* mark as healthy */
-			_healthy[i] = true;
-			_num_healthy++;
-			ret = OK;
-		}
-	}
-
-	return ret;
-}
-
-void
-OREOLED::bootloader_cmd_add_checksum(oreoled_cmd_t* cmd)
-{
-	if (cmd->num_bytes == 0 || cmd->num_bytes >= OREOLED_CMD_LENGTH_MAX) {
-		return;
-	}
-
-	/* write a basic 8-bit XOR checksum into the last byte of the command bytes array*/
+	/* Calculate XOR checksum and append to the command buffer */
+	cmd->num_bytes++;
 	uint8_t checksum_idx = cmd->num_bytes - 1;
+
+	/* XOR seed */
+	cmd->buff[checksum_idx] = OREOLED_BASE_I2C_ADDR + cmd->led_num;
+
+	/* XOR Calculation */
 	for (uint8_t i = 0; i < checksum_idx; i++) {
 		cmd->buff[checksum_idx] ^= cmd->buff[i];
 	}
+
+	return cmd->buff[checksum_idx];
 }
 
 int
@@ -1416,83 +480,8 @@ OREOLED::ioctl(struct file *filp, int cmd, unsigned long arg)
 		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
 			/* add command to queue for all healthy leds */
 			if (_healthy[i]) {
-				warnx("sending a reset... to %i", i);
 				new_cmd.led_num = i;
 				_cmd_queue->force(&new_cmd);
-				ret = OK;
-			}
-		}
-
-		return ret;
-
-	case OREOLED_BL_PING:
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i]) {
-				bootloader_ping(i);
-				ret = OK;
-			}
-		}
-
-		return ret;
-
-	case OREOLED_BL_VER:
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i]) {
-				bootloader_version(i);
-				ret = OK;
-			}
-		}
-
-		return ret;
-
-	case OREOLED_BL_FLASH:
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i]) {
-				bootloader_flash(i);
-				ret = OK;
-			}
-		}
-
-		return ret;
-
-	case OREOLED_BL_APP_VER:
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i]) {
-				bootloader_app_version(i);
-				ret = OK;
-			}
-		}
-
-		return ret;
-
-	case OREOLED_BL_APP_CRC:
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i]) {
-				bootloader_app_checksum(i);
-				ret = OK;
-			}
-		}
-
-		return ret;
-
-	case OREOLED_BL_SET_COLOUR:
-		new_cmd.led_num = OREOLED_ALL_INSTANCES;
-
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i]) {
-				bootloader_set_colour(i, ((oreoled_rgbset_t *) arg)->red, ((oreoled_rgbset_t *) arg)->green);
-				ret = OK;
-			}
-		}
-
-		return ret;
-
-	case OREOLED_BL_BOOT_APP:
-		new_cmd.led_num = OREOLED_ALL_INSTANCES;
-
-		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
-			if (_healthy[i]) {
-				bootloader_boot(i);
 				ret = OK;
 			}
 		}
@@ -1579,18 +568,10 @@ OREOLED::send_cmd(oreoled_cmd_t new_cmd)
 	return ret;
 }
 
-/* return the internal _is_ready flag indicating if initialisation is complete */
-bool
-OREOLED::is_ready()
-{
-	return _is_ready;
-}
-
 void
 oreoled_usage()
 {
 	warnx("missing command: try 'start', 'test', 'info', 'off', 'stop', 'reset', 'rgb 30 40 50', 'macro 4', 'gencall', 'bytes <lednum> 7 9 6'");
-	warnx("bootloader commands: try 'blping', 'blver', 'blappver', 'blappcrc', 'blcolour <red> <green>', 'blflash', 'blboot'");
 	warnx("options:");
 	warnx("    -b i2cbus (%d)", PX4_I2C_BUS_LED);
 	warnx("    -a addr (0x%x)", OREOLED_BASE_I2C_ADDR);
@@ -1641,20 +622,8 @@ oreoled_main(int argc, char *argv[])
 			i2cdevice = PX4_I2C_BUS_LED;
 		}
 
-		/* handle update flags */
-		bool autoupdate = false;
-		bool alwaysupdate = false;
-
-		if (argc > 2 && !strcmp(argv[2], "autoupdate")) {
-			warnx("autoupdate enabled");
-			autoupdate = true;
-		} else if (argc > 2 && !strcmp(argv[2], "alwaysupdate")) {
-			warnx("alwaysupdate enabled");
-			alwaysupdate = true;
-		}
-
 		/* instantiate driver */
-		g_oreoled = new OREOLED(i2cdevice, i2c_addr, autoupdate, alwaysupdate);
+		g_oreoled = new OREOLED(i2cdevice, i2c_addr);
 
 		/* check if object was created */
 		if (g_oreoled == nullptr) {
@@ -1666,15 +635,6 @@ oreoled_main(int argc, char *argv[])
 			delete g_oreoled;
 			g_oreoled = nullptr;
 			errx(1, "failed to start driver");
-		}
-
-		/* wait for up to 20 seconds for the driver become ready */
-		for (uint8_t i = 0; i < 20; i++) {
-			if (g_oreoled != nullptr && g_oreoled->is_ready()) {
-				break;
-			}
-
-			sleep(1);
 		}
 
 		exit(0);
@@ -1826,150 +786,6 @@ oreoled_main(int argc, char *argv[])
 
 		if ((ret = ioctl(fd, OREOLED_SEND_RESET, 0)) != OK) {
 			errx(1, "failed to run macro");
-		}
-
-		close(fd);
-		exit(ret);
-	}
-
-	/* attempt to flash all LEDS in bootloader mode*/
-	if (!strcmp(verb, "blflash")) {
-		if (argc < 2) {
-			errx(1, "Usage: oreoled blflash");
-		}
-
-		int fd = open(OREOLED0_DEVICE_PATH, 0);
-
-		if (fd == -1) {
-			errx(1, "Unable to open " OREOLED0_DEVICE_PATH);
-		}
-
-		if ((ret = ioctl(fd, OREOLED_BL_FLASH, 0)) != OK) {
-			errx(1, "failed to run flash");
-		}
-
-		close(fd);
-		exit(ret);
-	}
-
-	/* send bootloader boot request to all LEDS */
-	if (!strcmp(verb, "blboot")) {
-		if (argc < 2) {
-			errx(1, "Usage: oreoled blboot");
-		}
-
-		int fd = open(OREOLED0_DEVICE_PATH, 0);
-
-		if (fd == -1) {
-			errx(1, "Unable to open " OREOLED0_DEVICE_PATH);
-		}
-
-		if ((ret = ioctl(fd, OREOLED_BL_BOOT_APP, 0)) != OK) {
-			errx(1, "failed to run boot");
-		}
-
-		close(fd);
-		exit(ret);
-	}
-
-	/* send bootloader ping all LEDs */
-	if (!strcmp(verb, "blping")) {
-		if (argc < 2) {
-			errx(1, "Usage: oreoled blping");
-		}
-
-		int fd = open(OREOLED0_DEVICE_PATH, 0);
-
-		if (fd == -1) {
-			errx(1, "Unable to open " OREOLED0_DEVICE_PATH);
-		}
-
-		if ((ret = ioctl(fd, OREOLED_BL_PING, 0)) != OK) {
-			errx(1, "failed to run blping");
-		}
-
-		close(fd);
-		exit(ret);
-	}
-
-	/* ask all LEDs for their bootloader version */
-	if (!strcmp(verb, "blver")) {
-		if (argc < 2) {
-			errx(1, "Usage: oreoled blver");
-		}
-
-		int fd = open(OREOLED0_DEVICE_PATH, 0);
-
-		if (fd == -1) {
-			errx(1, "Unable to open " OREOLED0_DEVICE_PATH);
-		}
-
-		if ((ret = ioctl(fd, OREOLED_BL_VER, 0)) != OK) {
-			errx(1, "failed to get bootloader version");
-		}
-
-		close(fd);
-		exit(ret);
-	}
-
-	/* ask all LEDs for their application version */
-	if (!strcmp(verb, "blappver")) {
-		if (argc < 2) {
-			errx(1, "Usage: oreoled blappver");
-		}
-
-		int fd = open(OREOLED0_DEVICE_PATH, 0);
-
-		if (fd == -1) {
-			errx(1, "Unable to open " OREOLED0_DEVICE_PATH);
-		}
-
-		if ((ret = ioctl(fd, OREOLED_BL_APP_VER, 0)) != OK) {
-			errx(1, "failed to get boot app version");
-		}
-
-		close(fd);
-		exit(ret);
-	}
-
-	/* ask all LEDs for their application crc */
-	if (!strcmp(verb, "blappcrc")) {
-		if (argc < 2) {
-			errx(1, "Usage: oreoled blappcrc");
-		}
-
-		int fd = open(OREOLED0_DEVICE_PATH, 0);
-
-		if (fd == -1) {
-			errx(1, "Unable to open " OREOLED0_DEVICE_PATH);
-		}
-
-		if ((ret = ioctl(fd, OREOLED_BL_APP_CRC, 0)) != OK) {
-			errx(1, "failed to get boot app crc");
-		}
-
-		close(fd);
-		exit(ret);
-	}
-
-	/* set the default bootloader LED colour on all LEDs */
-	if (!strcmp(verb, "blcolour")) {
-		if (argc < 4) {
-			errx(1, "Usage: oreoled blcolour <red> <green>");
-		}
-
-		int fd = open(OREOLED0_DEVICE_PATH, 0);
-
-		if (fd == -1) {
-			errx(1, "Unable to open " OREOLED0_DEVICE_PATH);
-		}
-
-		uint8_t red = (uint8_t)strtol(argv[2], NULL, 0);
-		uint8_t green = (uint8_t)strtol(argv[3], NULL, 0);
-		oreoled_rgbset_t rgb_set = {OREOLED_ALL_INSTANCES, OREOLED_PATTERN_SOLID, red, green, 0};
-
-		if ((ret = ioctl(fd, OREOLED_BL_SET_COLOUR, (unsigned long)&rgb_set)) != OK) {
-			errx(1, "failed to set boot startup colours");
 		}
 
 		close(fd);

--- a/src/drivers/oreoled/oreoled_bootloader/module.mk
+++ b/src/drivers/oreoled/oreoled_bootloader/module.mk
@@ -2,7 +2,7 @@
 # OreoLED Bootloader Drivers
 #
 
-MODULE_COMMAND	= oreoled_bl
+MODULE_COMMAND	= oreoledbl
 SRCS			= oreoled_bootloader.cpp \
 					oreoled_bootloader_avr.cpp
 

--- a/src/drivers/oreoled/oreoled_bootloader/module.mk
+++ b/src/drivers/oreoled/oreoled_bootloader/module.mk
@@ -1,0 +1,9 @@
+#
+# OreoLED Bootloader Drivers
+#
+
+MODULE_COMMAND	= oreoled_bl
+SRCS			= oreoled_bootloader.cpp \
+					oreoled_bootloader_avr.cpp
+
+MAXOPTIMIZATION	= -Os

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.cpp
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * @file oreoled.cpp
+ * @file oreoled_bootloader.cpp
  * @author Angus Peart <angusp@gmail.com>
  */
 
@@ -129,7 +129,7 @@ oreoledbl_main(int argc, char *argv[])
 			break;
 
 		case 't':
-			target = oreoled_bl_parse_target(strdup(optarg));
+			target = oreoled_bl_parse_target(optarg);
 			if (target != OREOLED_BL_TARGET_INVALID) {
 				break;
 			}
@@ -213,14 +213,10 @@ oreoledbl_main(int argc, char *argv[])
 
 	if (!strcmp(verb, "stop")) {
 		/* delete the oreoled object if stop was requested, in addition to turning off the LED. */
-		if (!strcmp(verb, "stop")) {
-			OREOLED_BOOTLOADER *tmp_oreoled = g_oreoled_bl;
-			g_oreoled_bl = nullptr;
-			delete tmp_oreoled;
-			exit(0);
-		}
-
-		exit(ret);
+		OREOLED_BOOTLOADER *tmp_oreoled = g_oreoled_bl;
+		g_oreoled_bl = nullptr;
+		delete tmp_oreoled;
+		exit(0);
 	}
 
 	/* send reset request to all LEDS */

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.cpp
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.cpp
@@ -74,17 +74,6 @@ namespace
 	OREOLED_BOOTLOADER *g_oreoled_bl = nullptr;
 }
 
-void
-OREOLED_BOOTLOADER::cycle_trampoline(void *arg)
-{
-	OREOLED_BOOTLOADER *dev = (OREOLED_BOOTLOADER *)arg;
-
-	/* check global oreoled_bl and cycle */
-	if (g_oreoled_bl != nullptr) {
-		dev->cycle();
-	}
-}
-
 static void oreoled_bl_usage();
 static oreoled_bl_target_t oreoled_bl_parse_target(char* target);
 
@@ -188,19 +177,10 @@ oreoled_bl_main(int argc, char *argv[])
 		}
 
 		/* check object was created successfully */
-		if (g_oreoled_bl->init() != OK) {
+		if (g_oreoled_bl->update() != OK) {
 			delete g_oreoled_bl;
 			g_oreoled_bl = nullptr;
 			errx(1, "failed to start driver");
-		}
-
-		/* wait for up to 20 seconds for the driver become ready */
-		for (uint8_t i = 0; i < 20; i++) {
-			if (g_oreoled_bl != nullptr && g_oreoled_bl->is_ready()) {
-				break;
-			}
-
-			sleep(1);
 		}
 
 		exit(0);
@@ -211,12 +191,6 @@ oreoled_bl_main(int argc, char *argv[])
 		warnx("not started");
 		oreoled_bl_usage();
 		exit(1);
-	}
-
-	/* display driver status */
-	if (!strcmp(verb, "info")) {
-		g_oreoled_bl->info();
-		exit(0);
 	}
 
 	if (!strcmp(verb, "kill")) {

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.cpp
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.cpp
@@ -1,0 +1,400 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2012, 2013 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file oreoled.cpp
+ * @author Angus Peart <angusp@gmail.com>
+ */
+
+#include <nuttx/config.h>
+
+#include <drivers/device/i2c.h>
+#include <drivers/drv_hrt.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <sys/stat.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/wqueue.h>
+#include <nuttx/clock.h>
+
+#include <systemlib/perf_counter.h>
+#include <systemlib/err.h>
+#include <systemlib/systemlib.h>
+
+#include <board_config.h>
+
+#include <drivers/drv_oreoled.h>
+#include <drivers/drv_oreoled_bootloader.h>
+
+#include "oreoled_bootloader.h"
+#include "oreoled_bootloader_avr.h"
+
+/* for now, we only support one OREOLED */
+namespace
+{
+	OREOLED_BOOTLOADER *g_oreoled_bl = nullptr;
+}
+
+void
+OREOLED_BOOTLOADER::cycle_trampoline(void *arg)
+{
+	OREOLED_BOOTLOADER *dev = (OREOLED_BOOTLOADER *)arg;
+
+	/* check global oreoled_bl and cycle */
+	if (g_oreoled_bl != nullptr) {
+		dev->cycle();
+	}
+}
+
+static void oreoled_bl_usage();
+static oreoled_bl_target_t oreoled_bl_parse_target(char* target);
+
+extern "C" __EXPORT int oreoled_bl_main(int argc, char *argv[]);
+
+void
+oreoled_bl_usage()
+{
+	warnx("missing command: try 'update [force]', 'kill', 'ping', 'blver', 'ver', 'checksum', 'colour <red> <green>', 'flash', 'boot'");
+	warnx("options:");
+	warnx("    -t target (auto)");
+	warnx("    -b i2cbus (%d)", PX4_I2C_BUS_LED);
+	warnx("    -a addr (0x%x)", OREOLED_BASE_I2C_ADDR);
+}
+
+oreoled_bl_target_t
+oreoled_bl_parse_target(char *target)
+{
+	if (!strcmp(target, "avr")) {
+		return OREOLED_BL_TARGET_AVR;
+	} else if (!strcmp(target, "auto") == 0) {
+		return OREOLED_BL_TARGET_DEFAULT;
+	}
+
+	return OREOLED_BL_TARGET_INVALID;
+}
+
+int
+oreoled_bl_main(int argc, char *argv[])
+{
+	int i2cdevice = -1;
+	int i2c_addr = OREOLED_BASE_I2C_ADDR; /* 7bit */
+	oreoled_bl_target_t target = OREOLED_BL_TARGET_INVALID;
+
+	int ch;
+
+	/* jump over ping/ver/etc and look at options first */
+	while ((ch = getopt(argc, argv, "a:b:t:")) != EOF) {
+		switch (ch) {
+		case 'a':
+			i2c_addr = (int)strtol(optarg, NULL, 0);
+			break;
+
+		case 'b':
+			i2cdevice = (int)strtol(optarg, NULL, 0);
+			break;
+
+		case 't':
+			target = oreoled_bl_parse_target(strdup(optarg));
+			if (target != OREOLED_BL_TARGET_INVALID) {
+				break;
+			}
+			warnx("invalid target '%s' specified", optarg);
+
+		default:
+			oreoled_bl_usage();
+			exit(0);
+		}
+	}
+
+	if (optind >= argc) {
+		oreoled_bl_usage();
+		exit(1);
+	}
+
+	const char *verb = argv[optind];
+
+	int ret;
+
+	/* start driver */
+	if (!strcmp(verb, "update")) {
+		if (g_oreoled_bl != nullptr) {
+			errx(1, "already started");
+		}
+
+		/* by default use LED bus */
+		if (i2cdevice == -1) {
+			i2cdevice = PX4_I2C_BUS_LED;
+		}
+
+		/* handle update flag */
+		bool force_update = false;
+		if (argc > 2 && !strcmp(argv[2], "force")) {
+			warnx("forcing update");
+			force_update = true;
+		}
+
+		/* instantiate driver */
+		switch (target) {
+			case OREOLED_BL_TARGET_AVR:
+				g_oreoled_bl = new OREOLED_BOOTLOADER_AVR(i2cdevice, i2c_addr, force_update);
+				break;
+
+			default:
+				errx(1, "unable to instantiate target driver");
+		}
+
+		/* check if object was created */
+		if (g_oreoled_bl == nullptr) {
+			errx(1, "failed to allocated memory for driver");
+		}
+
+		/* check object was created successfully */
+		if (g_oreoled_bl->init() != OK) {
+			delete g_oreoled_bl;
+			g_oreoled_bl = nullptr;
+			errx(1, "failed to start driver");
+		}
+
+		/* wait for up to 20 seconds for the driver become ready */
+		for (uint8_t i = 0; i < 20; i++) {
+			if (g_oreoled_bl != nullptr && g_oreoled_bl->is_ready()) {
+				break;
+			}
+
+			sleep(1);
+		}
+
+		exit(0);
+	}
+
+	/* need the driver past this point */
+	if (g_oreoled_bl == nullptr) {
+		warnx("not started");
+		oreoled_bl_usage();
+		exit(1);
+	}
+
+	/* display driver status */
+	if (!strcmp(verb, "info")) {
+		g_oreoled_bl->info();
+		exit(0);
+	}
+
+	if (!strcmp(verb, "kill")) {
+		/* delete the oreoled object if stop was requested, in addition to turning off the LED. */
+		if (!strcmp(verb, "kill")) {
+			OREOLED_BOOTLOADER *tmp_oreoled = g_oreoled_bl;
+			g_oreoled_bl = nullptr;
+			delete tmp_oreoled;
+			exit(0);
+		}
+
+		exit(ret);
+	}
+
+	/* send reset request to all LEDS */
+	if (!strcmp(verb, "reset")) {
+		if (argc < 2) {
+			errx(1, "Usage: oreoledbl reset");
+		}
+
+		int fd = open(OREOLEDBL0_DEVICE_PATH, 0);
+
+		if (fd == -1) {
+			errx(1, "Unable to open " OREOLEDBL0_DEVICE_PATH);
+		}
+
+		if ((ret = g_oreoled_bl->ioctl(OREOLED_BL_RESET, 0)) != OK) {
+			errx(1, "failed to run reset");
+		}
+
+		close(fd);
+		exit(ret);
+	}
+
+	/* attempt to flash all LEDS in bootloader mode*/
+	if (!strcmp(verb, "flash")) {
+		if (argc < 2) {
+			errx(1, "Usage: oreoledbl flash");
+		}
+
+		int fd = open(OREOLEDBL0_DEVICE_PATH, 0);
+
+		if (fd == -1) {
+			errx(1, "Unable to open " OREOLEDBL0_DEVICE_PATH);
+		}
+
+		if ((ret = g_oreoled_bl->ioctl(OREOLED_BL_FLASH, 0)) != OK) {
+			errx(1, "failed to run flash");
+		}
+
+		close(fd);
+		exit(ret);
+	}
+
+	/* send bootloader boot request to all LEDS */
+	if (!strcmp(verb, "boot")) {
+		if (argc < 2) {
+			errx(1, "Usage: oreoledbl boot");
+		}
+
+		int fd = open(OREOLEDBL0_DEVICE_PATH, 0);
+
+		if (fd == -1) {
+			errx(1, "Unable to open " OREOLEDBL0_DEVICE_PATH);
+		}
+
+		if ((ret = g_oreoled_bl->ioctl(OREOLED_BL_BOOT_APP, 0)) != OK) {
+			errx(1, "failed to run boot");
+		}
+
+		close(fd);
+		exit(ret);
+	}
+
+	/* send bootloader ping all LEDs */
+	if (!strcmp(verb, "ping")) {
+		if (argc < 2) {
+			errx(1, "Usage: oreoledbl ping");
+		}
+
+		int fd = open(OREOLEDBL0_DEVICE_PATH, 0);
+
+		if (fd == -1) {
+			errx(1, "Unable to open " OREOLEDBL0_DEVICE_PATH);
+		}
+
+		if ((ret = g_oreoled_bl->ioctl(OREOLED_BL_PING, 0)) != OK) {
+			errx(1, "failed to run blping");
+		}
+
+		close(fd);
+		exit(ret);
+	}
+
+	/* ask all LEDs for their bootloader version */
+	if (!strcmp(verb, "blver")) {
+		if (argc < 2) {
+			errx(1, "Usage: oreoledbl ver");
+		}
+
+		int fd = open(OREOLEDBL0_DEVICE_PATH, 0);
+
+		if (fd == -1) {
+			errx(1, "Unable to open " OREOLEDBL0_DEVICE_PATH);
+		}
+
+		if ((ret = g_oreoled_bl->ioctl(OREOLED_BL_VER, 0)) != OK) {
+			errx(1, "failed to get bootloader version");
+		}
+
+		close(fd);
+		exit(ret);
+	}
+
+	/* ask all LEDs for their application version */
+	if (!strcmp(verb, "ver")) {
+		if (argc < 2) {
+			errx(1, "Usage: oreoledbl appver");
+		}
+
+		int fd = open(OREOLEDBL0_DEVICE_PATH, 0);
+
+		if (fd == -1) {
+			errx(1, "Unable to open " OREOLEDBL0_DEVICE_PATH);
+		}
+
+		if ((ret = g_oreoled_bl->ioctl(OREOLED_BL_APP_VER, 0)) != OK) {
+			errx(1, "failed to get app version");
+		}
+
+		close(fd);
+		exit(ret);
+	}
+
+	/* ask all LEDs for their application checksum */
+	if (!strcmp(verb, "checksum")) {
+		if (argc < 2) {
+			errx(1, "Usage: oreoledbl checksum");
+		}
+
+		int fd = open(OREOLEDBL0_DEVICE_PATH, 0);
+
+		if (fd == -1) {
+			errx(1, "Unable to open " OREOLEDBL0_DEVICE_PATH);
+		}
+
+		if ((ret = g_oreoled_bl->ioctl(OREOLED_BL_APP_CHECKSUM, 0)) != OK) {
+			errx(1, "failed to get app checksum");
+		}
+
+		close(fd);
+		exit(ret);
+	}
+
+	/* set the default bootloader LED colour on all LEDs */
+	if (!strcmp(verb, "colour")) {
+		if (argc < 4) {
+			errx(1, "Usage: oreoledbl colour <red> <green>");
+		}
+
+		int fd = open(OREOLEDBL0_DEVICE_PATH, 0);
+
+		if (fd == -1) {
+			errx(1, "Unable to open " OREOLEDBL0_DEVICE_PATH);
+		}
+
+		uint8_t red = (uint8_t)strtol(argv[2], NULL, 0);
+		uint8_t green = (uint8_t)strtol(argv[3], NULL, 0);
+		oreoled_rgbset_t rgb_set = {OREOLED_ALL_INSTANCES, OREOLED_PATTERN_SOLID, red, green, 0};
+
+		if ((ret = g_oreoled_bl->ioctl(OREOLED_BL_SET_COLOUR, (unsigned long)&rgb_set)) != OK) {
+			errx(1, "failed to set boot startup colours");
+		}
+
+		close(fd);
+		exit(ret);
+	}
+
+	oreoled_bl_usage();
+	exit(0);
+}

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.h
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.h
@@ -55,7 +55,8 @@ public:
 	OREOLED_BOOTLOADER() {};
 	virtual ~OREOLED_BOOTLOADER() {};
 
-	virtual int		update(void) = 0;
+	virtual	int		start(void) = 0;
+	virtual int		update(bool force) = 0;
 	virtual int		ioctl(const unsigned cmd, const unsigned long arg) = 0;
 };
 

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.h
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.h
@@ -1,0 +1,77 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2014 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file oreoled_bootloader.h
+ * @author Angus Peaty <angusp@gmail.com>
+ */
+
+#ifndef OREOLED_BOOTLOADER_H
+#define OREOLED_BOOTLOADER_H
+
+#include "oreoled_bootloader.h"
+
+enum oreoled_bl_target_t {
+	OREOLED_BL_TARGET_INVALID,
+	OREOLED_BL_TARGET_AVR,
+	OREOLED_BL_TARGET_ENUM_COUNT
+};
+
+#define OREOLED_BL_TARGET_DEFAULT		OREOLED_BL_TARGET_AVR
+
+class OREOLED_BOOTLOADER
+{
+public:
+	OREOLED_BOOTLOADER() {};
+	virtual ~OREOLED_BOOTLOADER() {};
+
+	virtual int		init() = 0;
+	virtual int		info() = 0;
+	virtual int		ioctl(unsigned cmd, unsigned long arg) = 0;
+
+	/* Start the update process */
+	virtual void	start() = 0;
+
+	/* Kill the update process */
+	virtual void	kill() = 0;
+
+	/* returns true once the driver finished bootloading and ready for commands */
+	virtual bool	is_ready() = 0;
+
+	void cycle_trampoline(void *arg);
+
+protected:
+	virtual void	cycle() = 0;
+};
+
+#endif /* OREOLED_BOOTLOADER_H */

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.h
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader.h
@@ -55,23 +55,8 @@ public:
 	OREOLED_BOOTLOADER() {};
 	virtual ~OREOLED_BOOTLOADER() {};
 
-	virtual int		init() = 0;
-	virtual int		info() = 0;
-	virtual int		ioctl(unsigned cmd, unsigned long arg) = 0;
-
-	/* Start the update process */
-	virtual void	start() = 0;
-
-	/* Kill the update process */
-	virtual void	kill() = 0;
-
-	/* returns true once the driver finished bootloading and ready for commands */
-	virtual bool	is_ready() = 0;
-
-	void cycle_trampoline(void *arg);
-
-protected:
-	virtual void	cycle() = 0;
+	virtual int		update(void) = 0;
+	virtual int		ioctl(const unsigned cmd, const unsigned long arg) = 0;
 };
 
 #endif /* OREOLED_BOOTLOADER_H */

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.cpp
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.cpp
@@ -206,14 +206,9 @@ OREOLED_BOOTLOADER_AVR::cycle()
 		work_queue(HPWORK, &_work, (worker_t)&OREOLED_BOOTLOADER::cycle_trampoline, this,
 			   USEC2TICK(OREOLED_STARTUP_INTERVAL_US));
 		return;
-	} else if (_force_update || _num_inboot || _is_ready) {
-		run_updates();
-
-		/* schedule another attempt in 20mS */
-		work_queue(HPWORK, &_work, (worker_t)&OREOLED_BOOTLOADER::cycle_trampoline, this,
-			   USEC2TICK(OREOLED_UPDATE_INTERVAL_US));
-		return;
 	}
+
+	run_updates();
 
 	kill();
 }
@@ -289,7 +284,9 @@ OREOLED_BOOTLOADER_AVR::run_updates(void)
 		boot_all();
 		coerce_healthy();
 		_num_inboot = 0;
-	} else if (!_is_ready) {
+	}
+
+	if (!_is_ready) {
 		/* indicate a ready state since startup has finished */
 		_is_ready = true;
 	}

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.cpp
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * @file oreoled.cpp
+ * @file oreoled_bootloader_avr.cpp
  * @author Angus Peart <angusp@gmail.com>
  */
 

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.cpp
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.cpp
@@ -1,0 +1,1263 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2012, 2013 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file oreoled.cpp
+ * @author Angus Peart <angusp@gmail.com>
+ */
+
+#include <nuttx/config.h>
+
+#include <drivers/device/i2c.h>
+#include <drivers/drv_hrt.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <sys/stat.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/wqueue.h>
+#include <nuttx/clock.h>
+
+#include <systemlib/perf_counter.h>
+#include <systemlib/err.h>
+#include <systemlib/systemlib.h>
+
+#include <board_config.h>
+
+#include <drivers/drv_oreoled.h>
+#include <drivers/drv_oreoled_bootloader.h>
+
+#include "oreoled_bootloader_avr.h"
+
+#define OREOLED_BL_TARGET_DEFAULT		OREOLED_BL_TARGET_AVR
+
+#define OREOLED_BOOT_FLASH_WAITMS		10
+
+#define OREOLED_BOOT_SUPPORTED_VER		0x01
+
+#define OREOLED_BOOT_CMD_PING			0x40
+#define OREOLED_BOOT_CMD_BL_VER			0x41
+#define OREOLED_BOOT_CMD_APP_VER		0x42
+#define OREOLED_BOOT_CMD_APP_CHECKSUM	0x43
+#define OREOLED_BOOT_CMD_SET_COLOUR		0x44
+
+#define OREOLED_BOOT_CMD_WRITE_FLASH_A	0x50
+#define OREOLED_BOOT_CMD_WRITE_FLASH_B	0x51
+#define OREOLED_BOOT_CMD_FINALISE_FLASH	0x55
+
+#define OREOLED_BOOT_CMD_BOOT_APP		0x60
+
+#define OREOLED_BL_I2C_RETRYCOUNT		2
+#define OEROLED_BOOT_COMMAND_RETRIES	10
+
+/* magic number used to verify the software reset is valid */
+#define OEROLED_RESET_NONCE				0x2A
+
+#define OREOLED_BOOT_CMD_PING_NONCE		0x2A
+#define OREOLED_BOOT_CMD_BOOT_NONCE		0xA2
+
+#define OREOLED_FW_FILE_HEADER_LENGTH	2
+#define OREOLED_FW_FILE_SIZE_LIMIT		6144
+#define OREOLED_FW_FILE					"/etc/firmware/oreoled.bin"
+
+
+#define OREOLED_STARTUP_TIMEOUT_USEC	2000000U			///< timeout looking for oreoleds 2 seconds after startup
+#define OREOLED_STARTUP_INTERVAL_US		(1000000U / 10U)	///< time in microseconds, run at 10hz
+#define OREOLED_UPDATE_INTERVAL_US		(1000000U / 50U)	///< time in microseconds, run at 50hz
+
+/* constructor */
+OREOLED_BOOTLOADER_AVR::OREOLED_BOOTLOADER_AVR(int bus, int i2c_addr, bool force_update) :
+	I2C("oreoledbl_avr", OREOLEDBL0_DEVICE_PATH, bus, i2c_addr, 100000),
+	_work{},
+	_num_healthy(0),
+	_num_inboot(0),
+	_force_update(force_update),
+	_is_bootloading(false),
+	_is_ready(false),
+	_fw_checksum(0x0000),
+	_probe_perf(perf_alloc(PC_ELAPSED, "oreoled_bl_probe")),
+	_comms_errors(perf_alloc(PC_COUNT, "oreoled_bl_comms_errors")),
+	_reply_errors(perf_alloc(PC_COUNT, "oreoled_bl_reply_errors"))
+{
+	/* initialise to unhealthy */
+	memset(_healthy, 0, sizeof(_healthy));
+
+	/* initialise to in application */
+	memset(_in_boot, 0, sizeof(_in_boot));
+
+	/* capture startup time */
+	_start_time = hrt_absolute_time();
+}
+
+/* destructor */
+OREOLED_BOOTLOADER_AVR::~OREOLED_BOOTLOADER_AVR()
+{
+	/* make sure we are truly inactive */
+	kill();
+
+	/* free perf counters */
+	perf_free(_probe_perf);
+	perf_free(_comms_errors);
+	perf_free(_reply_errors);
+}
+
+int
+OREOLED_BOOTLOADER_AVR::init()
+{
+	int ret;
+
+	/* initialise I2C bus */
+	ret = I2C::init();
+
+	if (ret != OK) {
+		return ret;
+	}
+
+	/* start work queue */
+	start();
+
+	return OK;
+}
+
+int
+OREOLED_BOOTLOADER_AVR::info()
+{
+	/* print health info on each LED */
+	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+		if (!_healthy[i]) {
+			warnx("oreo %u: BAD", (unsigned)i);
+
+		} else {
+			warnx("oreo %u: OK", (unsigned)i);
+		}
+	}
+
+	/* display perf info */
+	perf_print_counter(_probe_perf);
+	perf_print_counter(_comms_errors);
+	perf_print_counter(_reply_errors);
+
+	return OK;
+}
+
+void
+OREOLED_BOOTLOADER_AVR::start()
+{
+	/* schedule a cycle to start things */
+	work_queue(HPWORK, &_work, (worker_t)&OREOLED_BOOTLOADER::cycle_trampoline, this, 1);
+}
+
+void
+OREOLED_BOOTLOADER_AVR::kill()
+{
+	work_cancel(HPWORK, &_work);
+}
+
+void
+OREOLED_BOOTLOADER_AVR::cycle()
+{
+	/* check time since startup */
+	uint64_t now = hrt_absolute_time();
+	bool startup_timeout = (now - _start_time > OREOLED_STARTUP_TIMEOUT_USEC);
+
+	/* during startup period keep searching for unhealthy LEDs */
+	if (!startup_timeout && _num_healthy < OREOLED_NUM_LEDS) {
+		run_initial_discovery();
+
+		/* schedule another attempt in 0.1 sec */
+		work_queue(HPWORK, &_work, (worker_t)&OREOLED_BOOTLOADER::cycle_trampoline, this,
+			   USEC2TICK(OREOLED_STARTUP_INTERVAL_US));
+		return;
+	} else if (_force_update || _num_inboot || _is_ready) {
+		run_updates();
+
+		/* schedule another attempt in 20mS */
+		work_queue(HPWORK, &_work, (worker_t)&OREOLED_BOOTLOADER::cycle_trampoline, this,
+			   USEC2TICK(OREOLED_UPDATE_INTERVAL_US));
+		return;
+	}
+
+	kill();
+}
+
+void
+OREOLED_BOOTLOADER_AVR::run_initial_discovery(void)
+{
+	/* prepare command to turn off LED */
+	/* add two bytes of pre-amble to for higher signal to noise ratio */
+	uint8_t msg[] = {0xAA, 0x55, OREOLED_PATTERN_OFF, 0x00};
+
+	/* attempt to contact each unhealthy LED */
+	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+		if (!_healthy[i]) {
+			perf_begin(_probe_perf);
+
+			/* set I2C address */
+			set_address(OREOLED_BASE_I2C_ADDR + i);
+
+			/* Calculate XOR checksum and append to the i2c write data */
+			msg[sizeof(msg) - 1] = OREOLED_BASE_I2C_ADDR + i;
+
+			for (uint8_t j = 0; j < sizeof(msg) - 1; j++) {
+				msg[sizeof(msg) - 1] ^= msg[j];
+			}
+
+			/* send I2C command */
+			uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+			if (transfer(msg, sizeof(msg), reply, 3) == OK) {
+				if (reply[1] == OREOLED_BASE_I2C_ADDR + i &&
+				    reply[2] == msg[sizeof(msg) - 1]) {
+					warnx("oreoled %u ok - in bootloader", (unsigned)i);
+					_healthy[i] = true;
+					_num_healthy++;
+
+					/* If slaves are in application record that so we can reset if we need to bootload */
+					/* This additional check is required for LED firmwares below v1.3 and can be
+					   deprecated once all LEDs in the wild have firmware >= v1.3 */
+					if(ping(i) == OK) {
+						_in_boot[i] = true;
+						_num_inboot++;
+					}
+
+				/* Check for a reply with a checksum offset of 1,
+				   which indicates a response from firmwares >= 1.3 */
+				} else if (reply[1] == OREOLED_BASE_I2C_ADDR + i &&
+				    reply[2] == msg[sizeof(msg) - 1] + 1) {
+					warnx("oreoled %u ok - in application", (unsigned)i);
+					_healthy[i] = true;
+					_num_healthy++;
+
+				} else {
+					warnx("oreo reply errors: %u", (unsigned)_reply_errors);
+					perf_count(_reply_errors);
+				}
+
+			} else {
+				perf_count(_comms_errors);
+			}
+
+			perf_end(_probe_perf);
+		}
+	}
+}
+
+void
+OREOLED_BOOTLOADER_AVR::run_updates(void)
+{
+	update_application(_force_update);
+	_force_update = false;
+
+	if (_num_inboot > 0) {
+		boot_all();
+		coerce_healthy();
+		_num_inboot = 0;
+	} else if (!_is_ready) {
+		/* indicate a ready state since startup has finished */
+		_is_ready = true;
+	}
+}
+
+void
+OREOLED_BOOTLOADER_AVR::update_application(bool force_update)
+{
+	/* check booted oreoleds to see if the app can report it's checksum (release versions >= v1.2) */
+	if(!force_update) {
+		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+			if (_healthy[i] && !_in_boot[i]) {
+				/* put any out of date oreoleds into bootloader mode */
+				/* being in bootloader mode signals to be code below that the will likey need updating */
+				if (inapp_checksum(i) != firmware_checksum()) {
+					app_reset(i);
+				}
+			}
+		}
+	}
+
+	/* reset all healthy oreoleds if the number of outdated oreoled's is > 0 */
+	/* this is done for consistency, so if only one oreoled is updating, all LEDs show the same behaviour */
+	/* otherwise a single oreoled could appear broken or failed. */
+	if (_num_inboot > 0 || force_update) {
+		app_reset_all();
+
+		/* update each outdated and healthy LED in bootloader mode */
+		flash_all(force_update);
+
+		/* boot each healthy LED */
+		boot_all();
+
+		/* coerce LEDs with startup issues to be healthy again */
+		coerce_healthy();
+	}
+}
+
+int
+OREOLED_BOOTLOADER_AVR::app_reset(int led_num)
+{
+	_is_bootloading = true;
+	oreoled_cmd_t boot_cmd;
+	boot_cmd.led_num = led_num;
+
+	int ret = -1;
+
+	/* Set the current address */
+	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
+
+	/* send a reset */
+	boot_cmd.buff[0] = OREOLED_PATTERN_PARAMUPDATE;
+	boot_cmd.buff[1] = OREOLED_PARAM_RESET;
+	boot_cmd.buff[2] = OEROLED_RESET_NONCE;
+	boot_cmd.buff[3] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+	boot_cmd.num_bytes = 4;
+	cmd_add_checksum(&boot_cmd);
+
+	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+
+	/* send I2C command with a retry limit */
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
+		if (transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 3) == OK) {
+			if (reply[1] == (OREOLED_BASE_I2C_ADDR + boot_cmd.led_num) &&
+			    reply[2] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+				/* slave returned a valid response */
+				ret = OK;
+				/* set this LED as being in boot mode now */
+				_in_boot[led_num] = true;
+				_num_inboot++;
+				break;
+			}
+		}
+	}
+
+	/* Allow time for the LED to reboot */
+	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
+	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
+	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
+	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
+
+	_is_bootloading = false;
+	return ret;
+}
+
+int
+OREOLED_BOOTLOADER_AVR::app_reset_all(void)
+{
+	int ret = OK;
+
+	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+		if (_healthy[i] && !_in_boot[i]) {
+			/* reset the LED if it's not in the bootloader */
+			/* (this happens during a pixhawk OTA update, since the LEDs stay powered) */
+			if (app_reset(i) != OK) {
+				ret = -1;
+			}
+		}
+	}
+
+	return ret;
+}
+
+int
+OREOLED_BOOTLOADER_AVR::app_ping(int led_num)
+{
+	oreoled_cmd_t boot_cmd;
+	boot_cmd.led_num = led_num;
+
+	int ret = -1;
+
+	/* Set the current address */
+	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
+
+	/* send a pattern off command */
+	boot_cmd.buff[0] = 0xAA;
+	boot_cmd.buff[1] = 0x55;
+	boot_cmd.buff[2] = OREOLED_PATTERN_OFF;
+	boot_cmd.buff[3] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+	boot_cmd.num_bytes = 4;
+	cmd_add_checksum(&boot_cmd);
+
+	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+
+	/* send I2C command with a retry limit */
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
+		if (transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 3) == OK) {
+			if (reply[1] == (OREOLED_BASE_I2C_ADDR + boot_cmd.led_num) &&
+			    reply[2] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+				/* slave returned a valid response */
+				ret = OK;
+				break;
+			}
+		}
+	}
+
+	return ret;
+}
+
+uint16_t
+OREOLED_BOOTLOADER_AVR::inapp_checksum(int led_num)
+{
+	_is_bootloading = true;
+	oreoled_cmd_t boot_cmd;
+	boot_cmd.led_num = led_num;
+
+	uint16_t ret = 0x0000;
+
+	/* Set the current address */
+	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
+
+	boot_cmd.buff[0] = OREOLED_PATTERN_PARAMUPDATE;
+	boot_cmd.buff[1] = OREOLED_PARAM_APP_CHECKSUM;
+	boot_cmd.buff[2] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+	boot_cmd.num_bytes = 3;
+	cmd_add_checksum(&boot_cmd);
+
+	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
+		/* Send the I2C Write+Read */
+		memset(reply, 0, sizeof(reply));
+		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 6);
+
+		/* Check the response */
+		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
+		    reply[2] == OREOLED_PARAM_APP_CHECKSUM &&
+		    reply[5] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+			warnx("bl app checksum OK from LED %i", boot_cmd.led_num);
+			warnx("bl app checksum msb: 0x%x", reply[3]);
+			warnx("bl app checksum lsb: 0x%x", reply[4]);
+			ret = ((reply[3] << 8) | reply[4]);
+			break;
+
+		} else {
+			warnx("bl app checksum FAIL from LED %i", boot_cmd.led_num);
+			warnx("bl app checksum response  ADDR: 0x%x", reply[1]);
+			warnx("bl app checksum response   CMD: 0x%x", reply[2]);
+			warnx("bl app checksum response VER H: 0x%x", reply[3]);
+			warnx("bl app checksum response VER L: 0x%x", reply[4]);
+			warnx("bl app checksum response   XOR: 0x%x", reply[5]);
+
+			if (retry > 1) {
+				warnx("bl app checksum retrying LED %i", boot_cmd.led_num);
+
+			} else {
+				warnx("bl app checksum failed on LED %i", boot_cmd.led_num);
+				break;
+			}
+		}
+	}
+
+	_is_bootloading = false;
+	return ret;
+}
+
+int
+OREOLED_BOOTLOADER_AVR::ping(int led_num)
+{
+	_is_bootloading = true;
+	oreoled_cmd_t boot_cmd;
+	boot_cmd.led_num = led_num;
+
+	int ret = -1;
+
+	/* Set the current address */
+	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
+
+	boot_cmd.buff[0] = OREOLED_BOOT_CMD_PING;
+	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+	boot_cmd.num_bytes = 2;
+	cmd_add_checksum(&boot_cmd);
+
+	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
+		/* Send the I2C Write+Read */
+		memset(reply, 0, sizeof(reply));
+		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 5);
+
+		/* Check the response */
+		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
+		    reply[2] == OREOLED_BOOT_CMD_PING &&
+		    reply[3] == OREOLED_BOOT_CMD_PING_NONCE &&
+		    reply[4] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+			warnx("bl ping OK from LED %i", boot_cmd.led_num);
+			ret = OK;
+			break;
+
+		} else {
+			warnx("bl ping FAIL from LED %i", boot_cmd.led_num);
+			warnx("bl ping response  ADDR: 0x%x", reply[1]);
+			warnx("bl ping response   CMD: 0x%x", reply[2]);
+			warnx("bl ping response NONCE: 0x%x", reply[3]);
+			warnx("bl ping response   XOR: 0x%x", reply[4]);
+
+			if (retry > 1) {
+				warnx("bl ping retrying LED %i", boot_cmd.led_num);
+
+			} else {
+				warnx("bl ping failed on LED %i", boot_cmd.led_num);
+				break;
+			}
+		}
+	}
+
+	_is_bootloading = false;
+	return ret;
+}
+
+uint8_t
+OREOLED_BOOTLOADER_AVR::version(int led_num)
+{
+	_is_bootloading = true;
+	oreoled_cmd_t boot_cmd;
+	boot_cmd.led_num = led_num;
+
+	uint8_t ret = 0x00;
+
+	/* Set the current address */
+	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
+
+	boot_cmd.buff[0] = OREOLED_BOOT_CMD_BL_VER;
+	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+	boot_cmd.num_bytes = 2;
+	cmd_add_checksum(&boot_cmd);
+
+	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
+		/* Send the I2C Write+Read */
+		memset(reply, 0, sizeof(reply));
+		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 5);
+
+		/* Check the response */
+		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
+		    reply[2] == OREOLED_BOOT_CMD_BL_VER &&
+		    reply[3] == OREOLED_BOOT_SUPPORTED_VER &&
+		    reply[4] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+			warnx("bl ver from LED %i = %i", boot_cmd.led_num, reply[3]);
+			ret = reply[3];
+			break;
+
+		} else {
+			warnx("bl ver response  ADDR: 0x%x", reply[1]);
+			warnx("bl ver response   CMD: 0x%x", reply[2]);
+			warnx("bl ver response   VER: 0x%x", reply[3]);
+			warnx("bl ver response   XOR: 0x%x", reply[4]);
+
+			if (retry > 1) {
+				warnx("bl ver retrying LED %i", boot_cmd.led_num);
+
+			} else {
+				warnx("bl ver failed on LED %i", boot_cmd.led_num);
+				break;
+			}
+		}
+	}
+
+	_is_bootloading = false;
+	return ret;
+}
+
+uint16_t
+OREOLED_BOOTLOADER_AVR::app_version(int led_num)
+{
+	_is_bootloading = true;
+	oreoled_cmd_t boot_cmd;
+	boot_cmd.led_num = led_num;
+
+	uint16_t ret = 0x0000;
+
+	/* Set the current address */
+	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
+
+	boot_cmd.buff[0] = OREOLED_BOOT_CMD_APP_VER;
+	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+	boot_cmd.num_bytes = 2;
+	cmd_add_checksum(&boot_cmd);
+
+	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
+		/* Send the I2C Write+Read */
+		memset(reply, 0, sizeof(reply));
+		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 6);
+
+		/* Check the response */
+		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
+		    reply[2] == OREOLED_BOOT_CMD_APP_VER &&
+		    reply[5] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+			warnx("bl app version OK from LED %i", boot_cmd.led_num);
+			warnx("bl app version msb: 0x%x", reply[3]);
+			warnx("bl app version lsb: 0x%x", reply[4]);
+			ret = ((reply[3] << 8) | reply[4]);
+			break;
+
+		} else {
+			warnx("bl app version FAIL from LED %i", boot_cmd.led_num);
+			warnx("bl app version response  ADDR: 0x%x", reply[1]);
+			warnx("bl app version response   CMD: 0x%x", reply[2]);
+			warnx("bl app version response VER H: 0x%x", reply[3]);
+			warnx("bl app version response VER L: 0x%x", reply[4]);
+			warnx("bl app version response   XOR: 0x%x", reply[5]);
+
+			if (retry > 1) {
+				warnx("bl app version retrying LED %i", boot_cmd.led_num);
+
+			} else {
+				warnx("bl app version failed on LED %i", boot_cmd.led_num);
+				break;
+			}
+		}
+	}
+
+	_is_bootloading = false;
+	return ret;
+}
+
+uint16_t
+OREOLED_BOOTLOADER_AVR::app_checksum(int led_num)
+{
+	_is_bootloading = true;
+	oreoled_cmd_t boot_cmd;
+	boot_cmd.led_num = led_num;
+
+	uint16_t ret = 0x0000;
+
+	/* Set the current address */
+	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
+
+	boot_cmd.buff[0] = OREOLED_BOOT_CMD_APP_CHECKSUM;
+	boot_cmd.buff[1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+	boot_cmd.num_bytes = 2;
+	cmd_add_checksum(&boot_cmd);
+
+	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
+		/* Send the I2C Write+Read */
+		memset(reply, 0, sizeof(reply));
+		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 6);
+
+		/* Check the response */
+		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
+		    reply[2] == OREOLED_BOOT_CMD_APP_CHECKSUM &&
+		    reply[5] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+			warnx("bl app checksum OK from LED %i", boot_cmd.led_num);
+			warnx("bl app checksum msb: 0x%x", reply[3]);
+			warnx("bl app checksum lsb: 0x%x", reply[4]);
+			ret = ((reply[3] << 8) | reply[4]);
+			break;
+
+		} else {
+			warnx("bl app checksum FAIL from LED %i", boot_cmd.led_num);
+			warnx("bl app checksum response  ADDR: 0x%x", reply[1]);
+			warnx("bl app checksum response   CMD: 0x%x", reply[2]);
+			warnx("bl app checksum response VER H: 0x%x", reply[3]);
+			warnx("bl app checksum response VER L: 0x%x", reply[4]);
+			warnx("bl app checksum response   XOR: 0x%x", reply[5]);
+
+			if (retry > 1) {
+				warnx("bl app checksum retrying LED %i", boot_cmd.led_num);
+
+			} else {
+				warnx("bl app checksum failed on LED %i", boot_cmd.led_num);
+				break;
+			}
+		}
+	}
+
+	_is_bootloading = false;
+	return ret;
+}
+
+int
+OREOLED_BOOTLOADER_AVR::set_colour(int led_num, uint8_t red, uint8_t green)
+{
+	_is_bootloading = true;
+	oreoled_cmd_t boot_cmd;
+	boot_cmd.led_num = led_num;
+
+	int ret = -1;
+
+	/* Set the current address */
+	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
+
+	boot_cmd.buff[0] = OREOLED_BOOT_CMD_SET_COLOUR;
+	boot_cmd.buff[1] = red;
+	boot_cmd.buff[2] = green;
+	boot_cmd.buff[3] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+	boot_cmd.num_bytes = 4;
+	cmd_add_checksum(&boot_cmd);
+
+	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
+		/* Send the I2C Write+Read */
+		memset(reply, 0, sizeof(reply));
+		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 4);
+
+		/* Check the response */
+		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
+		    reply[2] == OREOLED_BOOT_CMD_SET_COLOUR &&
+		    reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+			warnx("bl set colour OK from LED %i", boot_cmd.led_num);
+			ret = OK;
+			break;
+
+		} else {
+			warnx("bl set colour FAIL from LED %i", boot_cmd.led_num);
+			warnx("bl set colour response  ADDR: 0x%x", reply[1]);
+			warnx("bl set colour response   CMD: 0x%x", reply[2]);
+			warnx("bl set colour response   XOR: 0x%x", reply[3]);
+
+			if (retry > 1) {
+				warnx("bl app colour retrying LED %i", boot_cmd.led_num);
+
+			} else {
+				warnx("bl app colour failed on LED %i", boot_cmd.led_num);
+				break;
+			}
+		}
+	}
+
+	_is_bootloading = false;
+	return ret;
+}
+
+int
+OREOLED_BOOTLOADER_AVR::flash(int led_num)
+{
+	_is_bootloading = true;
+	oreoled_cmd_t boot_cmd;
+	boot_cmd.led_num = led_num;
+
+	/* Open the bootloader file */
+	int fd = ::open(OREOLED_FW_FILE, O_RDONLY);
+
+	/* check for error opening the file */
+	if (fd < 0) {
+		return -1;
+	}
+
+	struct stat s;
+
+	/* attempt to stat the file */
+	if (stat(OREOLED_FW_FILE, &s) != 0) {
+		::close(fd);
+		return -1;
+	}
+
+	uint16_t fw_length = s.st_size - OREOLED_FW_FILE_HEADER_LENGTH;
+
+	/* sanity-check file size */
+	if (fw_length > OREOLED_FW_FILE_SIZE_LIMIT) {
+		::close(fd);
+		return -1;
+	}
+
+	uint8_t *buf = new uint8_t[s.st_size];
+
+	/* check that the buffer has been allocated */
+	if (buf == NULL) {
+		::close(fd);
+		return -1;
+	}
+
+	/* check that the firmware can be read into the buffer */
+	if (::read(fd, buf, s.st_size) != s.st_size) {
+		::close(fd);
+		delete[] buf;
+		return -1;
+	}
+
+	::close(fd);
+
+	/* Grab the version bytes from the binary */
+	uint8_t version_major = buf[0];
+	uint8_t version_minor = buf[1];
+
+	/* calculate flash pages (rounded up to nearest integer) */
+	uint8_t flash_pages = ((fw_length + 64 - 1) / 64);
+
+	/* Set the current address */
+	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
+
+	uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+
+	/* Loop through flash pages */
+	for (uint8_t page_idx = 0; page_idx < flash_pages; page_idx++) {
+
+		/* Send the first half of the 64 byte flash page */
+		memset(boot_cmd.buff, 0, sizeof(boot_cmd.buff));
+		boot_cmd.buff[0] = OREOLED_BOOT_CMD_WRITE_FLASH_A;
+		boot_cmd.buff[1] = page_idx;
+		memcpy(boot_cmd.buff + 2, buf + (page_idx * 64) + OREOLED_FW_FILE_HEADER_LENGTH, 32);
+		boot_cmd.buff[32 + 2] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+		boot_cmd.num_bytes = 32 + 3;
+		cmd_add_checksum(&boot_cmd);
+
+		for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
+			/* Send the I2C Write+Read */
+			memset(reply, 0, sizeof(reply));
+			transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 4);
+
+			/* Check the response */
+			if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
+			    reply[2] == OREOLED_BOOT_CMD_WRITE_FLASH_A &&
+			    reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+				warnx("bl flash %ia OK for LED %i", page_idx, boot_cmd.led_num);
+				break;
+
+			} else {
+				warnx("bl flash %ia FAIL for LED %i", page_idx, boot_cmd.led_num);
+				warnx("bl flash %ia response ADDR: 0x%x", page_idx, reply[1]);
+				warnx("bl flash %ia response  CMD: 0x%x", page_idx, reply[2]);
+				warnx("bl flash %ia response  XOR: 0x%x", page_idx, reply[3]);
+
+				if (retry > 1) {
+					warnx("bl flash %ia retrying LED %i", page_idx, boot_cmd.led_num);
+
+				} else {
+					warnx("bl flash %ia failed on LED %i", page_idx, boot_cmd.led_num);
+					delete[] buf;
+					return -1;
+				}
+			}
+		}
+
+		/* Send the second half of the 64 byte flash page */
+		memset(boot_cmd.buff, 0, sizeof(boot_cmd.buff));
+		boot_cmd.buff[0] = OREOLED_BOOT_CMD_WRITE_FLASH_B;
+		memcpy(boot_cmd.buff + 1, buf + (page_idx * 64) + 32 + OREOLED_FW_FILE_HEADER_LENGTH, 32);
+		boot_cmd.buff[32 + 1] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+		boot_cmd.num_bytes = 32 + 2;
+		cmd_add_checksum(&boot_cmd);
+
+		for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
+			/* Send the I2C Write+Read */
+			memset(reply, 0, sizeof(reply));
+			transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 4);
+
+			/* Check the response */
+			if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
+			    reply[2] == OREOLED_BOOT_CMD_WRITE_FLASH_B &&
+			    reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+				warnx("bl flash %ib OK for LED %i", page_idx, boot_cmd.led_num);
+				break;
+
+			} else {
+				warnx("bl flash %ib FAIL for LED %i", page_idx, boot_cmd.led_num);
+				warnx("bl flash %ib response ADDR: 0x%x", page_idx, reply[1]);
+				warnx("bl flash %ib response  CMD: 0x%x", page_idx, reply[2]);
+				warnx("bl flash %ib response  XOR: 0x%x", page_idx, reply[3]);
+
+				if (retry > 1) {
+					warnx("bl flash %ib retrying LED %i", page_idx, boot_cmd.led_num);
+
+				} else {
+					errx(1, "bl flash %ib failed on LED %i", page_idx, boot_cmd.led_num);
+					delete[] buf;
+					return -1;
+				}
+			}
+		}
+
+		/* Sleep to allow flash to write */
+		/* Wait extra long on the first write, to allow time for EEPROM updates */
+		if (page_idx == 0) {
+			usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
+
+		} else {
+			usleep(OREOLED_BOOT_FLASH_WAITMS * 1000);
+		}
+	}
+
+	uint16_t calculated_app_checksum = firmware_checksum();
+
+	/* Flash writes must have succeeded so finalise the flash */
+	boot_cmd.buff[0] = OREOLED_BOOT_CMD_FINALISE_FLASH;
+	boot_cmd.buff[1] = version_major;
+	boot_cmd.buff[2] = version_minor;
+	boot_cmd.buff[3] = (uint8_t)(fw_length >> 8);
+	boot_cmd.buff[4] = (uint8_t)(fw_length & 0xFF);
+	boot_cmd.buff[5] = (uint8_t)(calculated_app_checksum >> 8);
+	boot_cmd.buff[6] = (uint8_t)(calculated_app_checksum & 0xFF);
+	boot_cmd.buff[7] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+	boot_cmd.num_bytes = 8;
+	cmd_add_checksum(&boot_cmd);
+
+	/* Try to finalise for twice the amount of normal retries */
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES * 2; retry > 0; retry--) {
+		/* Send the I2C Write */
+		memset(reply, 0, sizeof(reply));
+		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 4);
+
+		/* Check the response */
+		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
+		    reply[2] == OREOLED_BOOT_CMD_FINALISE_FLASH &&
+		    reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+			warnx("bl finalise OK from LED %i", boot_cmd.led_num);
+			break;
+
+		} else {
+			warnx("bl finalise response  ADDR: 0x%x", reply[1]);
+			warnx("bl finalise response   CMD: 0x%x", reply[2]);
+			warnx("bl finalise response   XOR: 0x%x", reply[3]);
+
+			if (retry > 1) {
+				warnx("bl finalise retrying LED %i", boot_cmd.led_num);
+
+			} else {
+				warnx("bl finalise failed on LED %i", boot_cmd.led_num);
+				delete[] buf;
+				return -1;
+			}
+		}
+	}
+
+	/* allow time for flash to finalise */
+	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
+	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
+
+	/* clean up file buffer */
+	delete[] buf;
+
+	_is_bootloading = false;
+	return 1;
+}
+
+int
+OREOLED_BOOTLOADER_AVR::boot(int led_num)
+{
+	_is_bootloading = true;
+	oreoled_cmd_t boot_cmd;
+	boot_cmd.led_num = led_num;
+
+	int ret = -1;
+
+	/* Set the current address */
+	set_address(OREOLED_BASE_I2C_ADDR + boot_cmd.led_num);
+
+	boot_cmd.buff[0] = OREOLED_BOOT_CMD_BOOT_APP;
+	boot_cmd.buff[1] = OREOLED_BOOT_CMD_BOOT_NONCE;
+	boot_cmd.buff[2] = OREOLED_BASE_I2C_ADDR + boot_cmd.led_num;
+	boot_cmd.num_bytes = 3;
+	cmd_add_checksum(&boot_cmd);
+
+	for (uint8_t retry = OEROLED_BOOT_COMMAND_RETRIES; retry > 0; retry--) {
+		/* Send the I2C Write */
+		uint8_t reply[OREOLED_CMD_READ_LENGTH_MAX];
+		transfer(boot_cmd.buff, boot_cmd.num_bytes, reply, 4);
+
+		/* Check the response */
+		if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
+		    reply[2] == OREOLED_BOOT_CMD_BOOT_APP &&
+		    reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+			warnx("bl boot OK from LED %i", boot_cmd.led_num);
+			/* decrement the inboot counter so we don't get confused */
+			_in_boot[led_num] = false;
+			_num_inboot--;
+			ret = OK;
+			break;
+
+		} else if (reply[1] == OREOLED_BASE_I2C_ADDR + boot_cmd.led_num &&
+			   reply[2] == OREOLED_BOOT_CMD_BOOT_NONCE &&
+			   reply[3] == boot_cmd.buff[boot_cmd.num_bytes - 1]) {
+			warnx("bl boot error from LED %i: no app", boot_cmd.led_num);
+			break;
+
+		} else {
+			warnx("bl boot response  ADDR: 0x%x", reply[1]);
+			warnx("bl boot response   CMD: 0x%x", reply[2]);
+			warnx("bl boot response   XOR: 0x%x", reply[3]);
+
+			if (retry > 1) {
+				warnx("bl boot retrying LED %i", boot_cmd.led_num);
+
+			} else {
+				warnx("bl boot failed on LED %i", boot_cmd.led_num);
+				break;
+			}
+		}
+	}
+
+	/* allow time for the LEDs to boot */
+	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
+	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
+	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
+	usleep(OREOLED_BOOT_FLASH_WAITMS * 1000 * 10);
+
+	_is_bootloading = false;
+	return ret;
+}
+
+int
+OREOLED_BOOTLOADER_AVR::boot_all(void) {
+	int ret = OK;
+
+	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+		if (_healthy[i] && _in_boot[i]) {
+			/* boot the application */
+			if (boot(i) != OK) {
+				ret = -1;
+			}
+		}
+	}
+
+	return ret;
+}
+
+uint16_t
+OREOLED_BOOTLOADER_AVR::firmware_checksum(void)
+{
+	/* Calculate the 16 bit XOR checksum of the firmware on the first call of this function */
+	if (_fw_checksum == 0x0000) {
+		/* Open the bootloader file */
+		int fd = ::open(OREOLED_FW_FILE, O_RDONLY);
+
+		/* check for error opening the file */
+		if (fd < 0) {
+			return -1;
+		}
+
+		struct stat s;
+
+		/* attempt to stat the file */
+		if (stat(OREOLED_FW_FILE, &s) != 0) {
+			::close(fd);
+			return -1;
+		}
+
+		uint16_t fw_length = s.st_size - OREOLED_FW_FILE_HEADER_LENGTH;
+
+		/* sanity-check file size */
+		if (fw_length > OREOLED_FW_FILE_SIZE_LIMIT) {
+			::close(fd);
+			return -1;
+		}
+
+		uint8_t *buf = new uint8_t[s.st_size];
+
+		/* check that the buffer has been allocated */
+		if (buf == NULL) {
+			::close(fd);
+			return -1;
+		}
+
+		/* check that the firmware can be read into the buffer */
+		if (::read(fd, buf, s.st_size) != s.st_size) {
+			::close(fd);
+			delete[] buf;
+			return -1;
+		}
+
+		::close(fd);
+
+		/* Calculate a 16 bit XOR checksum of the flash */
+		/* Skip the first two bytes which are the version information, plus
+		   the next two bytes which are modified by the bootloader */
+		uint16_t calculated_app_checksum = 0x0000;
+
+		for (uint16_t j = 2 + OREOLED_FW_FILE_HEADER_LENGTH; j < s.st_size; j += 2) {
+			calculated_app_checksum ^= (buf[j] << 8) | buf[j + 1];
+		}
+
+		delete[] buf;
+
+		warnx("fw length = %i", fw_length);
+		warnx("fw checksum = %i", calculated_app_checksum);
+
+		/* Store the checksum so it's only calculated once */
+		_fw_checksum = calculated_app_checksum;
+	}
+
+	return _fw_checksum;
+}
+
+int
+OREOLED_BOOTLOADER_AVR::flash_all(bool force_update)
+{
+	int ret = -1;
+
+	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+		if (_healthy[i] && _in_boot[i]) {
+			int result;
+
+			if (force_update) {
+				result = flash(i);
+			} else if (app_checksum(i) != firmware_checksum()) {
+				/* only flash LEDs with an old version of the applictioon */
+				result = flash(i);
+			}
+
+			if (result != OK) {
+				ret = -1;
+			}
+		}
+	}
+
+	return ret;
+}
+
+int
+OREOLED_BOOTLOADER_AVR::coerce_healthy(void)
+{
+	int ret = -1;
+
+	/* check each unhealthy LED */
+	/* this re-checks "unhealthy" LEDs as they can sometimes power up with the wrong ID, */
+	/*  but will have the correct ID once they jump to the application and be healthy again */
+	for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+		if (!_healthy[i] && app_ping(i) == OK) {
+			/* mark as healthy */
+			_healthy[i] = true;
+			_num_healthy++;
+			ret = OK;
+		}
+	}
+
+	return ret;
+}
+
+void
+OREOLED_BOOTLOADER_AVR::cmd_add_checksum(oreoled_cmd_t* cmd)
+{
+	if (cmd->num_bytes == 0 || cmd->num_bytes >= OREOLED_CMD_LENGTH_MAX) {
+		return;
+	}
+
+	/* write a basic 8-bit XOR checksum into the last byte of the command bytes array*/
+	uint8_t checksum_idx = cmd->num_bytes - 1;
+	for (uint8_t i = 0; i < checksum_idx; i++) {
+		cmd->buff[checksum_idx] ^= cmd->buff[i];
+	}
+}
+
+int
+OREOLED_BOOTLOADER_AVR::ioctl(unsigned cmd, unsigned long arg)
+{
+	int ret = -ENODEV;
+
+	switch (cmd) {
+	case OREOLED_BL_RESET:
+		ret = app_reset_all();
+		return ret;
+
+	case OREOLED_BL_PING:
+		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+			if (_healthy[i]) {
+				ping(i);
+				ret = OK;
+			}
+		}
+
+		return ret;
+
+	case OREOLED_BL_VER:
+		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+			if (_healthy[i]) {
+				version(i);
+				ret = OK;
+			}
+		}
+
+		return ret;
+
+	case OREOLED_BL_FLASH:
+		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+			if (_healthy[i]) {
+				flash(i);
+				ret = OK;
+			}
+		}
+
+		return ret;
+
+	case OREOLED_BL_APP_VER:
+		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+			if (_healthy[i]) {
+				app_version(i);
+				ret = OK;
+			}
+		}
+
+		return ret;
+
+	case OREOLED_BL_APP_CHECKSUM:
+		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+			if (_healthy[i]) {
+				app_checksum(i);
+				ret = OK;
+			}
+		}
+
+		return ret;
+
+	case OREOLED_BL_SET_COLOUR:
+		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+			if (_healthy[i]) {
+				set_colour(i, ((oreoled_rgbset_t *) arg)->red, ((oreoled_rgbset_t *) arg)->green);
+				ret = OK;
+			}
+		}
+
+		return ret;
+
+	case OREOLED_BL_BOOT_APP:
+		for (uint8_t i = 0; i < OREOLED_NUM_LEDS; i++) {
+			if (_healthy[i]) {
+				boot(i);
+				ret = OK;
+			}
+		}
+
+		return ret;
+
+	default:
+		ret = EINVAL;
+	}
+
+	return ret;
+}
+
+/* return the internal _is_ready flag indicating if initialisation is complete */
+bool
+OREOLED_BOOTLOADER_AVR::is_ready()
+{
+	return _is_ready;
+}

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.h
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.h
@@ -1,0 +1,103 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2014 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file oreoled_bootloader_avr.h
+ * @author Angus Peaty <angusp@gmail.com>
+ */
+
+#ifndef OREOLED_BOOTLOADER_AVR_H
+#define OREOLED_BOOTLOADER_AVR_H
+
+#include "oreoled_bootloader.h"
+
+class OREOLED_BOOTLOADER_AVR : public OREOLED_BOOTLOADER, public device::I2C
+{
+public:
+	OREOLED_BOOTLOADER_AVR(int bus, int i2c_addr, bool force_update);
+	~OREOLED_BOOTLOADER_AVR();
+
+	int			init();
+	int			info();
+	int			ioctl(unsigned cmd, unsigned long arg);
+
+	void		start();
+	void		kill();
+
+	/* returns true once the driver finished bootloading and ready for commands */
+	bool		is_ready();
+
+protected:
+	void		cycle();
+
+private:
+	void		run_initial_discovery(void);
+	void		run_updates(void);
+
+	void		update_application(bool force_update);
+	int			app_reset(int led_num);
+	int			app_reset_all(void);
+	int			app_ping(int led_num);
+	uint16_t	inapp_checksum(int led_num);
+	int			ping(int led_num);
+	uint8_t		version(int led_num);
+	uint16_t	app_version(int led_num);
+	uint16_t	app_checksum(int led_num);
+	int			set_colour(int led_num, uint8_t red, uint8_t green);
+	int			flash(int led_num);
+	int			flash_all(bool force_update);
+	int			boot(int led_num);
+	int			boot_all(void);
+	uint16_t	firmware_checksum(void);
+	int			coerce_healthy(void);
+	void		cmd_add_checksum(oreoled_cmd_t* cmd);
+
+	/* internal variables */
+	work_s			_work;							///< work queue for scheduling reads
+	bool			_healthy[OREOLED_NUM_LEDS];		///< health of each LED
+	bool			_in_boot[OREOLED_NUM_LEDS];		///< true for each LED that is in bootloader mode
+	uint8_t			_num_healthy;					///< number of healthy LEDs
+	uint8_t			_num_inboot;					///< number of LEDs in bootloader
+	uint64_t		_start_time;					///< system time we first attempt to communicate with battery
+	bool			_force_update;					///< true if the driver should update all LEDs
+	bool			_is_bootloading;				///< true if a bootloading operation is in progress
+	bool			_is_ready;						///< set to true once the driver has completly initialised
+	uint16_t		_fw_checksum;					///< the current 16bit XOR checksum of the built in oreoled firmware binary
+
+	/* performance checking */
+	perf_counter_t      _probe_perf;
+	perf_counter_t      _comms_errors;
+	perf_counter_t      _reply_errors;
+};
+
+#endif /* OREOLED_BOOTLOADER_AVR_H */

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.h
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.h
@@ -47,36 +47,28 @@ public:
 	OREOLED_BOOTLOADER_AVR(int bus, int i2c_addr, bool force_update);
 	~OREOLED_BOOTLOADER_AVR();
 
-	int			init();
-	int			info();
-	int			ioctl(unsigned cmd, unsigned long arg);
-
-	void		start();
-	void		kill();
-
-	/* returns true once the driver finished bootloading and ready for commands */
-	bool		is_ready();
-
-protected:
-	void		cycle();
+	int			update(void);
+	int			ioctl(const unsigned cmd, const unsigned long arg);
 
 private:
-	void		run_initial_discovery(void);
+	void		print_info(void);
+	void		startup_discovery(void);
+	void		discover(void);
 	void		run_updates(void);
 
-	void		update_application(bool force_update);
-	int			app_reset(int led_num);
+	void		update_application(const bool force_update);
+	int			app_reset(const int led_num);
 	int			app_reset_all(void);
-	int			app_ping(int led_num);
-	uint16_t	inapp_checksum(int led_num);
-	int			ping(int led_num);
-	uint8_t		version(int led_num);
-	uint16_t	app_version(int led_num);
-	uint16_t	app_checksum(int led_num);
-	int			set_colour(int led_num, uint8_t red, uint8_t green);
-	int			flash(int led_num);
-	int			flash_all(bool force_update);
-	int			boot(int led_num);
+	int			app_ping(const int led_num);
+	uint16_t	inapp_checksum(const int led_num);
+	int			ping(const int led_num);
+	uint8_t		version(const int led_num);
+	uint16_t	app_version(const int led_num);
+	uint16_t	app_checksum(const int led_num);
+	int			set_colour(const int led_num, const uint8_t red, const uint8_t green);
+	int			flash(const int led_num);
+	int			flash_all(const bool force_update);
+	int			boot(const int led_num);
 	int			boot_all(void);
 	uint16_t	firmware_checksum(void);
 	int			coerce_healthy(void);
@@ -91,7 +83,6 @@ private:
 	uint64_t		_start_time;					///< system time we first attempt to communicate with battery
 	bool			_force_update;					///< true if the driver should update all LEDs
 	bool			_is_bootloading;				///< true if a bootloading operation is in progress
-	bool			_is_ready;						///< set to true once the driver has completly initialised
 	uint16_t		_fw_checksum;					///< the current 16bit XOR checksum of the built in oreoled firmware binary
 
 	/* performance checking */

--- a/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.h
+++ b/src/drivers/oreoled/oreoled_bootloader/oreoled_bootloader_avr.h
@@ -44,17 +44,18 @@
 class OREOLED_BOOTLOADER_AVR : public OREOLED_BOOTLOADER, public device::I2C
 {
 public:
-	OREOLED_BOOTLOADER_AVR(int bus, int i2c_addr, bool force_update);
+	OREOLED_BOOTLOADER_AVR(int bus, int i2c_addr);
 	~OREOLED_BOOTLOADER_AVR();
 
-	int			update(void);
+	int			start(void);
+	int			update(bool force);
 	int			ioctl(const unsigned cmd, const unsigned long arg);
 
 private:
 	void		print_info(void);
 	void		startup_discovery(void);
 	void		discover(void);
-	void		run_updates(void);
+	void		run_updates(bool force);
 
 	void		update_application(const bool force_update);
 	int			app_reset(const int led_num);
@@ -63,6 +64,7 @@ private:
 	uint16_t	inapp_checksum(const int led_num);
 	int			ping(const int led_num);
 	uint8_t		version(const int led_num);
+	int			version_is_supported(const uint8_t ver);
 	uint16_t	app_version(const int led_num);
 	uint16_t	app_checksum(const int led_num);
 	int			set_colour(const int led_num, const uint8_t red, const uint8_t green);
@@ -73,16 +75,15 @@ private:
 	uint16_t	firmware_checksum(void);
 	int			coerce_healthy(void);
 	void		cmd_add_checksum(oreoled_cmd_t* cmd);
+	int			response_is_valid(const oreoled_cmd_t* cmd, const uint8_t* response, const uint8_t response_len);
+	void		print_response(const uint8_t* response, const uint8_t response_length);
 
 	/* internal variables */
-	work_s			_work;							///< work queue for scheduling reads
 	bool			_healthy[OREOLED_NUM_LEDS];		///< health of each LED
 	bool			_in_boot[OREOLED_NUM_LEDS];		///< true for each LED that is in bootloader mode
 	uint8_t			_num_healthy;					///< number of healthy LEDs
 	uint8_t			_num_inboot;					///< number of LEDs in bootloader
 	uint64_t		_start_time;					///< system time we first attempt to communicate with battery
-	bool			_force_update;					///< true if the driver should update all LEDs
-	bool			_is_bootloading;				///< true if a bootloading operation is in progress
 	uint16_t		_fw_checksum;					///< the current 16bit XOR checksum of the built in oreoled firmware binary
 
 	/* performance checking */


### PR DESCRIPTION
This removes all of the bootloader specific code out of `oreoled.cpp` and into a separate driver+command, to simplify the original oreoled code and to allow for multiple bootloader targets (currently only the AVR).

The code in oreoled_bootloader doesn't use the work queue and will block startup, but will also return and not run again once it's updating is complete.

The startup command usage for APM is now like this:

```
# Solo OreoLEDs
if oreoledbl -t auto update
then
    echo "oreoledbl update complete"

    if oreoled start
    then
        echo "oreoled started OK"
    fi
fi
```
